### PR TITLE
More compiler optimizations

### DIFF
--- a/samples/todoapp/bin/index.js
+++ b/samples/todoapp/bin/index.js
@@ -392,8 +392,7 @@ view_TodoApp.prototype = $extend(React.Component.prototype,{
 		var unchecked = this.state.items.filter(function(item) {
 			return !item.checked;
 		}).length;
-		var listProps = { data : this.state.items};
-		return { '$$typeof' : $$tre, type : "div", props : { style : { margin : "10px"}, className : "app", children : [{ '$$typeof' : $$tre, type : "div", props : { className : "header", children : [React.createElement("input",{ ref : "input", placeholder : "Enter new task description"}),{ '$$typeof' : $$tre, type : "button", props : { onClick : $bind(this,this.addItem), className : "button-add", children : ["+"]}}]}},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : view_TodoList, props : listProps, ref : $bind(this,this.mountList)},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : "div", props : { className : "footer", children : [unchecked," task(s) left"]}}]}};
+		return { '$$typeof' : $$tre, type : "div", props : { style : { margin : "10px"}, className : "app", children : [{ '$$typeof' : $$tre, type : "div", props : { className : "header", children : [React.createElement("input",{ ref : "input", placeholder : "Enter new task description"}),{ '$$typeof' : $$tre, type : "button", props : { onClick : $bind(this,this.addItem), className : "button-add", children : ["+"]}}]}},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : view_TodoList, props : { data : this.state.items}, ref : $bind(this,this.mountList)},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : "div", props : { className : "footer", children : [unchecked," task(s) left"]}}]}};
 	}
 	,mountList: function(comp) {
 		console.log("List mounted " + Std.string(comp.props));
@@ -479,8 +478,5 @@ var $$tre = (typeof Symbol === "function" && Symbol.for && Symbol.for("react.ele
 msignal_SlotList.NIL = new msignal_SlotList(null,null);
 store_TodoActions.addItem = new msignal_Signal1();
 store_TodoActions.toggleItem = new msignal_Signal1();
-view_TodoApp.displayName = "TodoApp";
-view_TodoList.displayName = "TodoList";
-view_TodoListItem.displayName = "TodoListItem";
 Main.main();
 })(typeof console != "undefined" ? console : {log:function(){}});

--- a/samples/todoapp/src/view/TodoApp.hx
+++ b/samples/todoapp/src/view/TodoApp.hx
@@ -53,7 +53,7 @@ class TodoApp extends ReactComponentOfStateAndRefs<TodoAppState, TodoAppRefs>
 				React.createElement("input", { ref : "input", placeholder : "Enter new task description"}),
 				React.createElement("button", { onClick : addItem, className : "button-add"}, "+")
 			),
-			React.createElement("hr", { }),
+			React.createElement("hr"),
 			React.createElement(TodoList, { ref : mountList, data:state.items }),
 			React.createElement("hr", { }),
 			React.createElement("div", { className : "footer"}, unchecked, " task(s) left")

--- a/samples/todoapp/src/view/TodoApp.hx
+++ b/samples/todoapp/src/view/TodoApp.hx
@@ -1,5 +1,6 @@
 package view;
 
+import api.react.React;
 import api.react.ReactComponent;
 import api.react.ReactMacro.jsx;
 import js.html.InputElement;
@@ -34,7 +35,7 @@ class TodoApp extends ReactComponentOfStateAndRefs<TodoAppState, TodoAppRefs>
 	{
 		var unchecked = state.items.filter(function(item) return !item.checked).length;
 		
-		var listProps = { data:state.items };
+		/*var listProps = { data:state.items };
 		return jsx('
 			<div className="app" style={{margin:"10px"}}>
 				<div className="header">
@@ -46,7 +47,17 @@ class TodoApp extends ReactComponentOfStateAndRefs<TodoAppState, TodoAppRefs>
 				<hr/>
 				<div className="footer">$unchecked task(s) left</div>
 			</div>
-		');
+		');*/
+		return React.createElement("div", { style : { margin : "10px"}, className : "app"},
+			React.createElement("div", { className : "header"},
+				React.createElement("input", { ref : "input", placeholder : "Enter new task description"}),
+				React.createElement("button", { onClick : addItem, className : "button-add"}, "+")
+			),
+			React.createElement("hr", { }),
+			React.createElement(TodoList, { ref : mountList, data:state.items }),
+			React.createElement("hr", { }),
+			React.createElement("div", { className : "footer"}, unchecked, " task(s) left")
+		);
 	}
 	
 	function mountList(comp:ReactComponent)

--- a/src/lib/api/react/React.hx
+++ b/src/lib/api/react/React.hx
@@ -46,7 +46,13 @@ extern class React
 	#end
 	
 	#if (!debug && !react_no_inline)
-	macro public static function createElement(type:Expr, attrs:Expr, children:Array<Expr>):Expr {
+	macro public static function createElement(type:Expr, rest:Array<Expr>):Expr {
+		var attrs = null;
+		var children = null;
+		if (rest != null && rest.length > 0) {
+			attrs = rest[0];
+			children = rest.slice(1);
+		}
 		return ReactMacro.inlineElement(type, attrs, children, Context.currentPos());
 	}
 	#end

--- a/src/lib/api/react/React.hx
+++ b/src/lib/api/react/React.hx
@@ -1,4 +1,6 @@
 package api.react;
+import haxe.macro.Context;
+import haxe.macro.Expr;
 
 /**
 	https://facebook.github.io/react/docs/top-level-api.html
@@ -9,6 +11,7 @@ package api.react;
 @:native('React')
 extern class React
 {
+	#if !macro
 	/**
 		https://facebook.github.io/react/docs/top-level-api.html#react.proptypes
 	**/
@@ -17,7 +20,13 @@ extern class React
 	/**
 		https://facebook.github.io/react/docs/top-level-api.html#react.createelement
 	**/
+	#if (debug || react_no_inline)
 	public static function createElement(type:Dynamic, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactComponent;
+	#end
+	
+	@:noCompletion
+	@:native('createElement')
+	private static function _createElement(type:Dynamic, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactComponent;
 
 	/**
 		https://facebook.github.io/react/docs/top-level-api.html#react.cloneelement
@@ -33,6 +42,14 @@ extern class React
 		https://facebook.github.io/react/docs/top-level-api.html#react.children
 	**/
 	public static var Children:ReactChildren;
+	
+	#end
+	
+	#if (!debug && !react_no_inline)
+	macro public static function createElement(type:Expr, attrs:Expr, children:Array<Expr>):Expr {
+		return ReactMacro.inlineElement(type, attrs, children, Context.currentPos());
+	}
+	#end
 }
 
 extern interface ReactChildren

--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -23,7 +23,7 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 #end
 @:native('React.Component')
 @:keepSub 
-@:autoBuild(api.react.ReactMacro.setDisplayName())
+@:autoBuild(api.react.ReactMacro.tagComponent())
 extern class ReactComponentOf<TProps, TState, TRefs>
 {
 	static var defaultProps:Dynamic;
@@ -38,7 +38,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	**/
 	var refs(default, null):TRefs;
 
-	function new(props:TProps);
+	function new(?props:TProps);
 
 	/**
 		https://facebook.github.io/react/docs/component-api.html#forceupdate

--- a/src/lib/api/react/ReactMacro.hx
+++ b/src/lib/api/react/ReactMacro.hx
@@ -394,6 +394,7 @@ class ReactMacro
 		var ref:Expr = null;
 		var key:Expr = null;
 		var fields = null;
+		if (attrs == null) attrs = macro {};
 		
 		// verify it's an object literal and extract `ref` and `key`
 		switch (attrs.expr) {


### PR DESCRIPTION
- `React.createElement` can now also be inlined into a JSON literal,
- React Hot Reload 3 tagging option (`-D react_hot`): in debug mode, adds a `__source` property to `ReactComponent` classes.
- `displayName` is now only generated in release mode
