### PR TITLE
Add extend for setState which takes state mutator function

### DIFF
--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -48,8 +48,8 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/component-api.html#setstate
 	**/
-	@:overload(function(nextState: TState -> TProps -> TState, ?callback: Void -> Void): Void {})
-	@:overload(function(nextState: TState -> TState, ?callback: Void -> Void): Void {})
+	@:overload(function(nextState:TState -> TProps -> TState, ?callback:Void -> Void):Void {})
+	@:overload(function(nextState:TState -> TState, ?callback:Void -> Void):Void {})
 	function setState(nextState:TState, ?callback:Void -> Void):Void;
 
 	/**

--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -51,6 +51,11 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	function setState(nextState:TState, ?callback:Void -> Void):Void;
 
 	/**
+		https://facebook.github.io/react/docs/component-api.html#setstate
+	**/
+	function setState((previousState:TState, ?currentProps:TProps):TState, ?callback:Void -> Void):Void;
+	
+	/**
 		https://facebook.github.io/react/docs/component-specs.html#render
 	**/
 	function render():ReactComponent;

--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -53,7 +53,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/component-api.html#setstate
 	**/
-	function setState((previousState:TState, ?currentProps:TProps):TState, ?callback:Void -> Void):Void;
+	function setState((previousState:TState, ?currentProps:TProps) -> TState, ?callback:Void -> Void):Void;
 	
 	/**
 		https://facebook.github.io/react/docs/component-specs.html#render

--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -53,7 +53,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/component-api.html#setstate
 	**/
-	function setState((previousState:TState, ?currentProps:TProps) -> TState, ?callback:Void -> Void):Void;
+	function setState(nextState: (previousState:TState, ?currentProps:TProps) -> TState, ?callback:Void -> Void):Void;
 	
 	/**
 		https://facebook.github.io/react/docs/component-specs.html#render

--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -48,12 +48,9 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/component-api.html#setstate
 	**/
+	@:overload(function(nextState: TState -> TProps -> TState, ?callback: Void -> Void): Void {})
+	@:overload(function(nextState: TState -> TState, ?callback: Void -> Void): Void {})
 	function setState(nextState:TState, ?callback:Void -> Void):Void;
-
-	/**
-		https://facebook.github.io/react/docs/component-api.html#setstate
-	**/
-	function setState(nextState: (previousState:TState, ?currentProps:TProps) -> TState, ?callback:Void -> Void):Void;
 	
 	/**
 		https://facebook.github.io/react/docs/component-specs.html#render

--- a/src/lib/api/react/ReactComponent.hx
+++ b/src/lib/api/react/ReactComponent.hx
@@ -51,7 +51,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	@:overload(function(nextState: TState -> TProps -> TState, ?callback: Void -> Void): Void {})
 	@:overload(function(nextState: TState -> TState, ?callback: Void -> Void): Void {})
 	function setState(nextState:TState, ?callback:Void -> Void):Void;
-	
+
 	/**
 		https://facebook.github.io/react/docs/component-specs.html#render
 	**/


### PR DESCRIPTION
This is helpful for when you need to adjust state in a more involved way that a partial state object can offer. Example:

```
this.setState(function (previousState) {
    var nextState = // TODO: Clone the previousState!!! This is to avoid data races.

    // Eg: Manipulation of a deep structure. Notice how previousState is not mutated!
    nextState.groups[0].item[7].url = "todo";

    return nextState;
})
```
