### PR TITLE
Better positions

### DIFF
--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -32,9 +32,12 @@ class ReactMacro
 	static function parseJsx(jsx:String, pos:Position):Expr
 	{
 		jsx = JsxSanitize.process(jsx);
-		var xml = try Xml.parse(jsx) catch(err:Dynamic) {
-			if(Std.is(err, haxe.xml.Parser.XmlParserException)) {
-				var err:haxe.xml.Parser.XmlParserException = err;
+		var xml = 
+			try
+				Xml.parse(jsx)
+			#if (haxe_ver >= 3.3)
+			catch(err:haxe.xml.Parser.XmlParserException)
+			{
 				var posInfos = Context.getPosInfos(pos);
 				var realPos = Context.makePosition({
 					file: posInfos.file,
@@ -43,8 +46,10 @@ class ReactMacro
 				});
 				Context.fatalError('Invalid JSX: ' + err.message, realPos);
 			}
-			Context.fatalError('Invalid JSX: ' + err, err.pos ? err.pos : pos);
-		}
+			#end
+			catch(err:Dynamic)
+				Context.fatalError('Invalid JSX: ' + err, err.pos ? err.pos : pos);
+		
 		var ast = JsxParser.process(xml);
 		var expr = parseJsxNode(ast, pos);
 		return expr;

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -31,19 +31,23 @@ class ReactMacro
 	#if macro
 	static function parseJsx(jsx:String, pos:Position):Expr
 	{
-		try 
-		{
-			jsx = JsxSanitize.process(jsx);
-			var xml = Xml.parse(jsx);
-			var ast = JsxParser.process(xml);
-			var expr = parseJsxNode(ast, pos);
-			return expr;
-		}
-		catch (err:Dynamic)
-		{
+		jsx = JsxSanitize.process(jsx);
+		var xml = try Xml.parse(jsx) catch(err:Dynamic) {
+			if(Std.is(err, haxe.xml.Parser.XmlParserException)) {
+				var err:haxe.xml.Parser.XmlParserException = err;
+				var posInfos = Context.getPosInfos(pos);
+				var realPos = Context.makePosition({
+					file: posInfos.file,
+					min: posInfos.min + err.position,
+					max: posInfos.max + err.position,
+				});
+				Context.fatalError('Invalid JSX: ' + err.message, realPos);
+			}
 			Context.fatalError('Invalid JSX: ' + err, err.pos ? err.pos : pos);
-			return null;
 		}
+		var ast = JsxParser.process(xml);
+		var expr = parseJsxNode(ast, pos);
+		return expr;
 	}
 
 	static function parseJsxNode(ast:JsxAst, pos:Position)
@@ -59,6 +63,7 @@ class ReactMacro
 			case JsxAst.Node(isHtml, path, attributes, jsxChildren):
 				// parse type
 				var type = isHtml ? macro $v{path[0]} : macro $p{path};
+				type.pos = pos;
 				
 				// parse attributes
 				var attrs = [];


### PR DESCRIPTION
Better error position reporting:

1. when there is syntax error in the xml itself, the err pos will correctly pinpoint the problematic xml
2. when there is typing error (unknown identifier, etc), the err pos will point to the jsx call (we cannot pinpoint the position in the xml because the xml parser doesn't store the pos after it finishes parsing)