### PR TITLE
Type createElement properly

### DIFF
--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -21,7 +21,7 @@ extern class React
 	/**
 		https://facebook.github.io/react/docs/react-api.html#createelement
 	**/
-	public static function createElement(type:haxe.extern.EitherType<String, Class<ReactComponent>>, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
+	public static function createElement(type:CreateElementType, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#cloneelement
@@ -69,3 +69,5 @@ extern interface ReactChildren
 	**/
 	function toArray(children:Dynamic):Array<Dynamic>;
 }
+
+typedef CreateElementType = haxe.extern.EitherType<haxe.extern.EitherType<String, haxe.Constraints.Function>, Class<ReactComponent>>;

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -21,7 +21,7 @@ extern class React
 	/**
 		https://facebook.github.io/react/docs/react-api.html#createelement
 	**/
-	public static function createElement(type:Dynamic, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
+	public static function createElement(type:haxe.extern.EitherType<String, Class<ReactComponent>>, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#cloneelement


### PR DESCRIPTION
Actually `haxe.Contraints.Function` can be more strictly typed as `?Dynamic->ReactElement`, what do you think?

I found this enhancement very important, because I am always bugged by name clashes. Say I have a component named `Home` and an enum value named `Home` as well. Then `Home` in `jsx('<Home/>')` may end up being resolved as the enum value (due to import sequence, etc), and the `type:Dynamic` in createElement doesn't catch that. As a result I spend a lot of time figuring out the problem until I read the output source, and that happened quite a few times already :(