### PR TITLE
JSX Optimizer: default props

### DIFF
--- a/samples/todoapp/bin/index.js
+++ b/samples/todoapp/bin/index.js
@@ -393,7 +393,7 @@ view_TodoApp.prototype = $extend(React.Component.prototype,{
 			return !item.checked;
 		}).length;
 		var listProps = { data : this.state.items};
-		return { '$$typeof' : $$tre, type : "div", props : { style : { margin : "10px"}, className : "app", children : [{ '$$typeof' : $$tre, type : "div", props : { className : "header", children : [React.createElement("input",{ ref : "input", placeholder : "Enter new task description"}),{ '$$typeof' : $$tre, type : "button", props : { onClick : $bind(this,this.addItem), className : "button-add", children : "+"}}]}},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : view_TodoList, props : listProps, ref : $bind(this,this.mountList)},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : "div", props : { className : "footer", children : [{ '$$typeof' : $$tre, type : "b", props : { children : unchecked}}," task(s) left"]}}]}};
+		return { '$$typeof' : $$tre, type : "div", props : { style : { margin : "10px"}, className : "app", children : [{ '$$typeof' : $$tre, type : "div", props : { className : "header", children : [React.createElement("input",{ ref : "input", placeholder : "Enter new task description"}),{ '$$typeof' : $$tre, type : "button", props : { onClick : $bind(this,this.addItem), className : "button-add", children : "+"}}]}},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : view_TodoList, props : Object.assign({ },{ padding : "10px"},listProps,{ className : "list"}), ref : $bind(this,this.mountList)},{ '$$typeof' : $$tre, type : "hr", props : { }},{ '$$typeof' : $$tre, type : "div", props : { className : "footer", children : [{ '$$typeof' : $$tre, type : "b", props : { children : unchecked}}," task(s) left"]}}]}};
 	}
 	,mountList: function(comp) {
 		console.log("List mounted " + Std.string(comp.props));
@@ -413,7 +413,8 @@ view_TodoList.__name__ = true;
 view_TodoList.__super__ = React.Component;
 view_TodoList.prototype = $extend(React.Component.prototype,{
 	render: function() {
-		return { '$$typeof' : $$tre, type : "ul", props : Object.assign({ },this.props,{ onClick : $bind(this,this.toggleChecked), className : "list", children : this.createChildren()})};
+		var style = { padding : this.props.padding};
+		return { '$$typeof' : $$tre, type : "ul", props : { style : style, onClick : $bind(this,this.toggleChecked), className : this.props.className, children : this.createChildren()}};
 	}
 	,createChildren: function() {
 		var _g = [];
@@ -422,7 +423,7 @@ view_TodoList.prototype = $extend(React.Component.prototype,{
 		while(_g1 < _g2.length) {
 			var entry = _g2[_g1];
 			++_g1;
-			_g.push({ '$$typeof' : $$tre, type : view_TodoListItem, props : { data : entry}, key : entry.id});
+			_g.push({ '$$typeof' : $$tre, type : view_TodoListItem, props : { padding : "5px", data : entry, border : "solid 1px #363"}, key : entry.id});
 		}
 		return _g;
 	}
@@ -444,10 +445,11 @@ view_TodoListItem.prototype = $extend(React.Component.prototype,{
 		return nextProps.data.checked != this.checked;
 	}
 	,render: function() {
+		var style = { padding : this.props.padding, border : this.props.border};
 		var entry = this.props.data;
 		this.checked = entry.checked;
 		var id = "item-" + entry.id;
-		return { '$$typeof' : $$tre, type : "li", props : { id : id, className : this.checked?"checked":"", children : entry.label}};
+		return { '$$typeof' : $$tre, type : "li", props : { id : id, style : style, className : this.checked?"checked":"", children : entry.label}};
 	}
 });
 var $_, $fid = 0;
@@ -479,5 +481,10 @@ msignal_SlotList.NIL = new msignal_SlotList(null,null);
 var $$tre = (typeof Symbol === "function" && Symbol.for && Symbol.for("react.element")) || 0xeac7;
 store_TodoActions.addItem = new msignal_Signal1();
 store_TodoActions.toggleItem = new msignal_Signal1();
+view_TodoApp.displayName = "TodoApp";
+view_TodoList.defaultProps = { padding : "10px", className : "list"};
+view_TodoList.displayName = "TodoList";
+view_TodoListItem.defaultProps = { padding : "10px", border : "solid 1px #363"};
+view_TodoListItem.displayName = "TodoListItem";
 Main.main();
 })(typeof console != "undefined" ? console : {log:function(){}});

--- a/samples/todoapp/src/view/TodoApp.hx
+++ b/samples/todoapp/src/view/TodoApp.hx
@@ -43,7 +43,7 @@ class TodoApp extends ReactComponentOfStateAndRefs<TodoAppState, TodoAppRefs>
 					<button className="button-add" onClick=$addItem>+</button>
 				</div>
 				<hr/>
-				<$TodoList ref={mountList} {...listProps}/>
+				<$TodoList ref={mountList} {...listProps} className="list"/>
 				<hr/>
 				<div className="footer"><b>$unchecked</b> task(s) left</div>
 			</div>

--- a/samples/todoapp/src/view/TodoList.hx
+++ b/samples/todoapp/src/view/TodoList.hx
@@ -8,11 +8,18 @@ import store.TodoActions;
 import store.TodoItem;
 
 typedef TodoListProps = {
-	data:Array<TodoItem>
+	?padding:String,
+	?className:String,
+	?data:Array<TodoItem>
 }
 
 class TodoList extends ReactComponentOfProps<TodoListProps>
 {
+	static var defaultProps:TodoListProps = {
+		padding: '10px',
+		className: 'list'
+	}
+	
 	public function new(props:TodoListProps)
 	{
 		super(props);
@@ -20,8 +27,12 @@ class TodoList extends ReactComponentOfProps<TodoListProps>
 	
 	override public function render() 
 	{
+		var style = {
+			padding: props.padding
+		};
+		
 		return jsx('
-			<ul className="list" onClick=$toggleChecked {...props}>
+			<ul className=${props.className} style=$style onClick=$toggleChecked>
 				${createChildren()}
 			</ul>
 		');
@@ -29,7 +40,7 @@ class TodoList extends ReactComponentOfProps<TodoListProps>
 	
 	function createChildren() 
 	{
-		return [for (entry in props.data) jsx('<TodoListItem key={entry.id} data={entry} />')];
+		return [for (entry in props.data) jsx('<TodoListItem key={entry.id} data={entry} padding="5px" />')];
 	}
 	
 	function toggleChecked(e:Event)
@@ -44,12 +55,19 @@ class TodoList extends ReactComponentOfProps<TodoListProps>
 }
 
 typedef TodoItemProps = {
-	data:TodoItem
+	?data:TodoItem,
+	?padding:String,
+	?border:String
 }
 
 class TodoListItem extends ReactComponentOfProps<TodoItemProps>
 {
 	var checked:Bool;
+	
+	static var defaultProps:TodoItemProps = {
+		padding: '10px',
+		border: 'solid 1px #363'
+	}
 	
 	public function new(props:TodoItemProps)
 	{
@@ -63,11 +81,15 @@ class TodoListItem extends ReactComponentOfProps<TodoItemProps>
 	
 	override public function render() 
 	{
+		var style = {
+			padding: props.padding,
+			border: props.border
+		};
 		var entry:TodoItem = props.data;
 		checked = entry.checked;
 		var id = 'item-${entry.id}';
 		return jsx('
-			<li id = $id className = ${checked ? "checked" : ""}>
+			<li id=$id className=${checked ? "checked" : ""} style=$style>
 				${entry.label}
 			</li>
 		');

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -23,7 +23,7 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 #end
 @:native('React.Component')
 @:keepSub 
-@:autoBuild(react.ReactMacro.tagComponent())
+@:autoBuild(react.ReactMacro.buildComponent())
 extern class ReactComponentOf<TProps, TState, TRefs>
 {
 	static var defaultProps:Dynamic;

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -191,15 +191,7 @@ class ReactMacro
 		#end
 		
 		// do not use literals for externs: we don't know their defaultProps
-		switch(Context.typeof(type)) {
-			case TType(_.get() => t, _):
-				switch(Context.getType(t.module)) {
-					case TInst(_.get() => t, _):
-						if (t.isExtern) return false;
-					default:
-				}
-			default:
-		}
+		if (isExternRef(type)) return false;
 		
 		if (ref == null) return true;
 		
@@ -208,6 +200,15 @@ class ReactMacro
 			case TFun(_): true; 
 			default: false; 
 		}
+	}
+	
+	static function isExternRef(type:Expr) 
+	{
+		return try switch(Context.getType(ExprTools.toString(type))) {
+			case TInst(_.get() => t, _): t.isExtern;
+			default: false;
+		}
+		catch (err:Dynamic) false;
 	}
 	
 	static function makeProps(spread:Array<Expr>, attrs:Array<{field:String, expr:Expr}>, pos:Position) 
@@ -302,7 +303,6 @@ class ReactMacro
 				switch (field.kind) {
 					case FieldType.FVar(_, _.expr => EObjectDecl(props)):
 						defaultPropsMap.set('Class<$qname>', props.copy());
-						return;
 					default:
 				}
 				return;

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -190,6 +190,17 @@ class ReactMacro
 		return false;
 		#end
 		
+		// do not use literals for externs: we don't know their defaultProps
+		switch(Context.typeof(type)) {
+			case TType(_.get() => t, _):
+				switch(Context.getType(t.module)) {
+					case TInst(_.get() => t, _):
+						if (t.isExtern) return false;
+					default:
+				}
+			default:
+		}
+		
 		if (ref == null) return true;
 		
 		// only refs as functions are allowed in literals, strings require the full createElement context 

--- a/src/lib/react/jsx/JsxParser.hx
+++ b/src/lib/react/jsx/JsxParser.hx
@@ -2,7 +2,7 @@ package react.jsx;
 
 using StringTools;
 
-#if (macro || munit)
+#if (macro || munit || display)
 enum JsxAst 
 {
 	Node(isHtml:Bool, path:Array<String>, attributes:Array<{name:String, value:String}>, children:Array<JsxAst>);

--- a/test/src/ReactMacroTest.hx
+++ b/test/src/ReactMacroTest.hx
@@ -3,6 +3,7 @@ package;
 import massive.munit.Assert;
 import react.ReactComponent;
 import react.ReactMacro.jsx;
+import support.sub.CompExternModule;
 import support.sub.CompModule;
 
 class CompBasic extends ReactComponent {	
@@ -13,12 +14,20 @@ class CompDefaults extends ReactComponent {
 		defB:42
 	}
 }
+extern class CompExtern extends ReactComponent {
+}
+
 
 class ReactMacroTest
 {
 
-	public function new() 
+	public function new() {}
+	
+	@BeforeClass
+	public function setup()
 	{
+		untyped window.CompExtern = function() {};
+		untyped window.CompExternModule = function() {};
 	}
 
 	@Test
@@ -60,6 +69,27 @@ class ReactMacroTest
 		var e = jsx('<CompBasic a="foo" />');
 		Assert.areEqual(CompBasic, e.type);
 		assertHasProps(e.props, ['a'], ['foo']);
+	}
+	
+	@Test
+	public function extern_component_qualified_module_should_DEOPT() 
+	{
+		var e = jsx('<support.sub.CompExternModule />');
+		Assert.areEqual('NATIVE', e.type);
+	}
+	
+	@Test
+	public function extern_component_module_should_DEOPT() 
+	{
+		var e = jsx('<CompExternModule />');
+		Assert.areEqual('NATIVE', e.type);
+	}
+	
+	@Test
+	public function extern_component_should_DEOPT() 
+	{
+		var e = jsx('<CompExtern />');
+		Assert.areEqual('NATIVE', e.type);
 	}
 	
 	@Test
@@ -110,6 +140,14 @@ class ReactMacroTest
 	public function component_in_sub_package_with_defaultProps() 
 	{
 		var e = jsx('<CompModule />');
+		Assert.areEqual(CompModule, e.type);
+		assertHasProps(e.props, ['defA', 'defB'], ['B', 43]);
+	}
+	
+	@Test
+	public function qualified_component_in_sub_package_with_defaultProps() 
+	{
+		var e = jsx('<support.sub.CompModule />');
 		Assert.areEqual(CompModule, e.type);
 		assertHasProps(e.props, ['defA', 'defB'], ['B', 43]);
 	}

--- a/test/src/ReactMacroTest.hx
+++ b/test/src/ReactMacroTest.hx
@@ -1,0 +1,255 @@
+package;
+
+import massive.munit.Assert;
+import react.ReactComponent;
+import react.ReactMacro.jsx;
+import support.sub.CompModule;
+
+class CompBasic extends ReactComponent {	
+}
+class CompDefaults extends ReactComponent {	
+	static public var defaultProps = {
+		defA:'A',
+		defB:42
+	}
+}
+
+class ReactMacroTest
+{
+
+	public function new() 
+	{
+	}
+
+	@Test
+	public function DOM_without_props() 
+	{
+		var e = jsx('<div/>');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, []);
+	}
+	
+	@Test
+	public function DOM_with_const_props() 
+	{
+		var e = jsx('<div a="foo" />');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['a'], ['foo']);
+	}
+	
+	@Test
+	public function DOM_with_const_and_binding_props() 
+	{
+		var foo = 12;
+		var e = jsx('<div a="foo" b=$foo />');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['a', 'b'], ['foo', 12]);
+	}
+	
+	@Test
+	public function function_with_props() 
+	{
+		var e = jsx('<RenderFunction a="foo" />');
+		Assert.areEqual(RenderFunction, e.type);
+		assertHasProps(e.props, ['a'], ['foo']);
+	}
+	
+	@Test
+	public function component_with_props() 
+	{
+		var e = jsx('<CompBasic a="foo" />');
+		Assert.areEqual(CompBasic, e.type);
+		assertHasProps(e.props, ['a'], ['foo']);
+	}
+	
+	@Test
+	public function DOM_with_spread() 
+	{
+		var o = {
+			a:'foo',
+			b:12
+		}
+		var e = jsx('<div {...o} />');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['a', 'b'], ['foo', 12]);
+	}
+	
+	@Test
+	public function DOM_with_spread_and_prop() 
+	{
+		var o = {
+			a:'foo',
+			b:12
+		}
+		var e = jsx('<div {...o} c="bar" />');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['a', 'b', 'c'], ['foo', 12, 'bar']);
+	}
+	
+	@Test
+	public function DOM_with_spread_and_prop_override() 
+	{
+		var o = {
+			a:'foo',
+			b:12
+		}
+		var e = jsx('<div {...o} a="bar" />');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['a', 'b'], ['bar', 12]);
+	}
+	
+	@Test
+	public function component_with_defaultProps() 
+	{
+		var e = jsx('<CompDefaults />');
+		Assert.areEqual(CompDefaults, e.type);
+		assertHasProps(e.props, ['defA', 'defB'], ['A', 42]);
+	}
+	
+	@Test
+	public function component_in_sub_package_with_defaultProps() 
+	{
+		var e = jsx('<CompModule />');
+		Assert.areEqual(CompModule, e.type);
+		assertHasProps(e.props, ['defA', 'defB'], ['B', 43]);
+	}
+	
+	@Test
+	public function component_with_defaultProps_and_spread() 
+	{
+		var o = {
+			a:'foo',
+			b:12
+		}
+		var e = jsx('<CompDefaults {...o}/>');
+		Assert.areEqual(CompDefaults, e.type);
+		assertHasProps(e.props, ['defA', 'defB', 'a', 'b'], ['A', 42, 'foo', 12]);
+	}
+	
+	@Test
+	public function component_with_defaultProps_and_prop_override() 
+	{
+		var e = jsx('<CompDefaults defA="foo"/>');
+		Assert.areEqual(CompDefaults, e.type);
+		assertHasProps(e.props, ['defA', 'defB'], ['foo', 42]);
+	}
+	
+	@Test
+	public function component_with_defaultProps_and_spread_override() 
+	{
+		var o = {
+			defA:'foo',
+			b:12
+		}
+		var e = jsx('<CompDefaults {...o}/>');
+		Assert.areEqual(CompDefaults, e.type);
+		assertHasProps(e.props, ['defA', 'defB', 'b'], ['foo', 42, 12]);
+	}
+	
+	@Test
+	public function component_with_defaultProps_and_spread_and_prop_override() 
+	{
+		var o = {
+			defA:'foo',
+			b:12
+		}
+		var e = jsx('<CompDefaults {...o} defA="bar" />');
+		Assert.areEqual(CompDefaults, e.type);
+		assertHasProps(e.props, ['defA', 'defB', 'b'], ['bar', 42, 12]);
+	}
+	
+	@Test
+	public function DOM_with_ref_function_should_be_inlined() 
+	{
+		function setRef() {};
+		var e = jsx('<div ref=$setRef />');
+		Assert.areEqual('div', e.type);
+		Assert.areEqual(setRef, e.ref);
+		assertHasProps(e.props, []);
+	}
+	
+	@Test
+	public function DOM_with_ref_const_string_should_be_DEOPT() 
+	{
+		var e = jsx('<div ref="myref" />');
+		Assert.areEqual('NATIVE', e.type);
+	}
+	
+	@Test
+	public function DOM_with_ref_string_should_be_DEOPT() 
+	{
+		var setRef = 'myRef';
+		var e = jsx('<div ref=$setRef />');
+		Assert.areEqual('NATIVE', e.type);
+	}
+	
+	@Test
+	public function DOM_with_ref_unknown_should_be_DEOPT() 
+	{
+		var setRef:Dynamic = function() {};
+		var e = jsx('<div ref=$setRef />');
+		Assert.areEqual('NATIVE', e.type);
+	}
+
+	@Test
+	public function DOM_with_single_child_text_should_NOT_be_array() 
+	{
+		var e = jsx('<div>hello</div>');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['children']);
+		var children = e.props.children;
+		Assert.areEqual('hello', children);
+	}
+
+	@Test
+	public function DOM_with_single_child_node_should_NOT_be_array() 
+	{
+		var e = jsx('<div><span/></div>');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['children']);
+		var children = e.props.children;
+		Assert.isFalse(Std.is(children, Array));
+		Assert.areEqual('span', children.type);
+	}
+
+	@Test
+	public function DOM_with_single_child_binding_should_NOT_be_array() 
+	{
+		var o = {};
+		var e = jsx('<div>${o}</div>');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['children'], [o]);
+	}
+
+	@Test
+	public function DOM_with_children_should_be_array() 
+	{
+		var e = jsx('<div>hello <span/></div>');
+		Assert.areEqual('div', e.type);
+		assertHasProps(e.props, ['children']);
+		var children = e.props.children;
+		Assert.isTrue(Std.is(children, Array));
+		Assert.areEqual('hello ', children[0]);
+		Assert.areEqual('span', children[1].type);
+	}
+	
+	/* TOOLS */
+	
+	function assertHasProps(o:Dynamic, names:Array<String>, ?values:Array<Dynamic>) 
+	{
+		var props = Reflect.fields(o);
+		Assert.areEqual(names.length, props.length);
+		for (i in 0...names.length)
+		{
+			var name = names[i];
+			Assert.areNotEqual( -1, props.indexOf(name));
+			if (values != null && values[i] != null)
+				Assert.areEqual(values[i], Reflect.field(o, name));
+		}
+	}
+	
+	function RenderFunction() 
+	{
+		return jsx('<div/>');
+	}
+}

--- a/test/src/TestSuite.hx
+++ b/test/src/TestSuite.hx
@@ -2,6 +2,7 @@ import massive.munit.TestSuite;
 
 import JsxParserTest;
 import JsxSanitizeTest;
+import ReactMacroTest;
 
 /**
  * Auto generated Test Suite for MassiveUnit.
@@ -17,5 +18,6 @@ class TestSuite extends massive.munit.TestSuite
 
 		add(JsxParserTest);
 		add(JsxSanitizeTest);
+		add(ReactMacroTest);
 	}
 }

--- a/test/src/react/React.hx
+++ b/test/src/react/React.hx
@@ -3,13 +3,9 @@ package react;
 import react.ReactComponent.ReactElement;
 
 /**
-	https://facebook.github.io/react/docs/react-api.html
+	STUB
 **/
-#if (!react_global)
-@:jsRequire("react")
-#end
-@:native('React')
-extern class React
+class React
 {
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.proptypes
@@ -19,17 +15,26 @@ extern class React
 	/**
 		https://facebook.github.io/react/docs/react-api.html#createelement
 	**/
-	public static function createElement(type:CreateElementType, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
+	public static function createElement(type:CreateElementType, ?attrs:Dynamic, ?children:Dynamic):ReactElement
+	{
+		return untyped { type:'NATIVE' };
+	}
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#cloneelement
 	**/
-	public static function cloneElement(element:ReactElement, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
+	public static function cloneElement(element:ReactElement, ?attrs:Dynamic, ?children:Dynamic):ReactElement
+	{
+		return untyped { type:'NATIVE' };
+	}
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#isvalidelement
 	**/
-	public static function isValidElement(object:Dynamic):Bool;
+	public static function isValidElement(object:Dynamic):Bool
+	{
+		return true;
+	}
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children

--- a/test/src/react/ReactComponent.hx
+++ b/test/src/react/ReactComponent.hx
@@ -8,7 +8,7 @@ typedef ReactComponentProps = {
 }
 
 /**
-	https://facebook.github.io/react/docs/react-component.html
+	STUB CLASSES
 **/
 typedef ReactComponent = ReactComponentOf<Dynamic, Dynamic, Dynamic>;
 typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Dynamic, Dynamic>;
@@ -18,14 +18,12 @@ typedef ReactComponentOfStateAndRefs<TState, TRefs> = ReactComponentOf<Dynamic, 
 typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState, Dynamic>;
 typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, Dynamic, TRefs>;
 
-#if (!react_global)
-@:jsRequire("react", "Component")
-#end
-@:native('React.Component')
-@:keepSub 
 @:autoBuild(react.ReactMacro.buildComponent())
-extern class ReactComponentOf<TProps, TState, TRefs>
+class ReactComponentOf<TProps, TState, TRefs>
 {
+	static var defaultProps:Dynamic;
+	static var contextTypes:Dynamic;
+
 	var props(default, null):TProps;
 	var state(default, null):TState;
 	var context(default, null):Dynamic;
@@ -35,66 +33,62 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	**/
 	var refs(default, null):TRefs;
 
-	function new(?props:TProps);
+	function new(?props:TProps) {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#forceupdate
 	**/
-	function forceUpdate(?callback:Void -> Void):Void;
+	function forceUpdate(?callback:Void -> Void):Void {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#setstate
 	**/
-	@:overload(function(nextState:TState -> TProps -> TState, ?callback:Void -> Void):Void {})
-	@:overload(function(nextState:TState -> TState, ?callback:Void -> Void):Void {})
-	function setState(nextState:TState, ?callback:Void -> Void):Void;
+	function setState(nextState:Dynamic, ?callback:Void -> Void):Void {};
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#render
 	**/
-	function render():ReactElement;
+	function render():ReactElement { return null; }
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentwillmount
 	**/
-	function componentWillMount():Void;
+	function componentWillMount():Void {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentdidmount
 	**/
-	function componentDidMount():Void;
+	function componentDidMount():Void {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentwillunmount
 	**/
-	function componentWillUnmount():Void;
+	function componentWillUnmount():Void {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentwillreceiveprops
 	**/
-	function componentWillReceiveProps(nextProps:TProps):Void;
+	function componentWillReceiveProps(nextProps:TProps):Void {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#shouldcomponentupdate
 	**/
-	dynamic function shouldComponentUpdate(nextProps:TProps, nextState:TState):Bool;
+	dynamic function shouldComponentUpdate(nextProps:TProps, nextState:TState):Bool { return true; }
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentwillupdate
 	**/
-	function componentWillUpdate(nextProps:TProps, nextState:TState):Void;
+	function componentWillUpdate(nextProps:TProps, nextState:TState):Void {}
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentdidupdate
 	**/
-	function componentDidUpdate(prevProps:TProps, prevState:TState):Void;
-	
-	#if (js && !debug && !react_no_inline)
+	function componentDidUpdate(prevProps:TProps, prevState:TState):Void {}
+
 	static function __init__():Void {
 		// required magic value to tag literal react elements
 		untyped __js__("var $$tre = (typeof Symbol === \"function\" && Symbol.for && Symbol.for(\"react.element\")) || 0xeac7");
 	}
-	#end
 }
 
 typedef ReactElement = {

--- a/test/src/support/sub/CompExternModule.hx
+++ b/test/src/support/sub/CompExternModule.hx
@@ -1,0 +1,8 @@
+package support.sub;
+import react.ReactComponent;
+
+@:native('CompExternModule')
+extern class CompExternModule extends ReactComponent
+{
+	public function new();
+}

--- a/test/src/support/sub/CompModule.hx
+++ b/test/src/support/sub/CompModule.hx
@@ -1,0 +1,17 @@
+package support.sub;
+
+import react.ReactComponent;
+
+class CompModule extends ReactComponent
+{
+	static public var defaultProps = {
+		defA:'B',
+		defB:43
+	}
+
+	public function new() 
+	{
+		super();
+	}
+	
+}


### PR DESCRIPTION
Components' `defaultProps` must be merged in the literal Json when doing createElement inlining.
Fixes #57 

2 cases are handled:
1. no spreads used: `defaultProps` are applied to the props object,
```javascript
class Comp extends ReactComponent {
  static var defaultProps = { p1:"0", p2:"2" };
  ...
}
```
```xml
<Comp p1="1"/>
```
Results in:
```javascript
{ type:Comp, props:{ p1:"1", p2:"2" }}
```

2. with spread: using `Object.assign` to combine `defaultProps` (only props missing) with the spread object and the direct props.
```xml
<Comp p1="1" {...foo} />
```
Results in:
```javascript
{ type:Comp, props:Object.assign({}, { p2:"2" }, foo, { p1:"1"}) }
```

