### PR TITLE
Hot reload fix

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -7,7 +7,7 @@
     "massive","elsassph"
   ],
 	"releasenote": "See https://github.com/massiveinteractive/haxe-react/blob/master/readme.md",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"url": "https://github.com/massiveinteractive/haxe-react",
 	"classPath": "src/lib",
 	"dependencies": 

--- a/mdk/info.json
+++ b/mdk/info.json
@@ -1,4 +1,4 @@
 {
 	"name": "api-react",
-	"version": "1.1.0"
+	"version": "1.1.1"
 }

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -35,7 +35,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	**/
 	var refs(default, null):TRefs;
 
-	function new(?props:TProps);
+	function new(?props:TProps, ?context:Dynamic);
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#forceupdate

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -324,50 +324,16 @@ class ReactMacro
 	
 	static function addTagSource(fields:Array<Field>, inClass:ClassType, pos:Position)
 	{
+		// add a __fileName__ static field
 		var className = inClass.name;
 		var fileName = Context.getPosInfos(inClass.pos).file;
-		var tag = macro if (untyped window.__REACT_HOT_LOADER__) untyped __REACT_HOT_LOADER__.register($i{className}, $v{className}, $v{fileName});
-		var register = macro $p{[className, '__hot__']}();
 		
 		fields.push({
-			name:'__hot__',
+			name:'__fileName__',
 			access:[Access.AStatic],
-			kind:FieldType.FFun({
-				args:[],
-				ret:null,
-				expr:tag
-			}),
+			kind:FieldType.FVar(null, macro $v{fileName}),
 			pos:pos
 		});
-		
-		// append tag to existing __init__
-		for (field in fields)
-			if (field.name == '__init__')
-			{
-				switch (field.kind) {
-					case FFun(f):
-						f.expr = macro {
-							${f.expr};
-							$register;
-						}
-					default:
-						Context.warning('__init__ declaration not supported to hot-reload tagging', field.pos);
-				}
-				return;
-			}
-		
-		// add new __init__ function with tag
-		fields.push({
-			name:'__init__',
-			access:[Access.AStatic, Access.APrivate],
-			kind:FieldType.FFun({
-				args:[],
-				ret:null,
-				expr:register
-			}),
-			pos:pos
-		});
-		return;
 	}
 	
 	static function addDisplayName(fields:Array<Field>, inClass:ClassType, pos:Position)


### PR DESCRIPTION
Using `__init__` to register React components for hot reload is too early. Removing auto-init and only annotating  the filename to enable post-processing tools to insert the registration properly.