### PR TITLE
Added debug warnings for avoidable renders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,3 +184,14 @@ return {$$typeof:Symbol.for('react.element'), type:'div', props:{className:'foo'
 This behaviour can be **disabled** using `-D react_no_inline`.
 
 Additionally, setting `-D react_monomorphic` will include both `ref` and `key` fields even when they are null in order to create monomorphic inlined objects. 
+
+
+## Optimization tools
+
+### Avoidable renders warning
+
+Setting `-D react_render_warning` will enable runtime warnings for avoidable renders.
+
+This will add a `componentDidUpdate` (or update the existing one) where a **shallowCompare** is done on current and previous props and state. If both did not change, a warning will be displayed in the console.
+
+False positives can happen if your props are not flat, due to the shallowCompare.

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -5,7 +5,7 @@ typedef ReactComponentProps = {
 	/**
 		Children have to be manipulated using React.Children.*
 	**/
-	@:optional var children:Dynamic; 
+	@:optional var children:Dynamic;
 }
 
 /**
@@ -23,9 +23,12 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 @:jsRequire("react", "Component")
 #end
 @:native('React.Component')
-@:keepSub 
+@:keepSub
 @:autoBuild(react.ReactMacro.buildComponent())
 @:autoBuild(react.ReactTypeMacro.alterComponentSignatures())
+#if (debug && react_render_warning)
+@:autoBuild(react.ReactDebugMacro.buildComponent())
+#end
 extern class ReactComponentOf<TProps, TState, TRefs>
 {
 	var props(default, null):TProps;
@@ -88,7 +91,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 		https://facebook.github.io/react/docs/react-component.html#componentdidupdate
 	**/
 	function componentDidUpdate(prevProps:TProps, prevState:TState):Void;
-	
+
 	#if (js && !debug && !react_no_inline)
 	static function __init__():Void {
 		// required magic value to tag literal react elements

--- a/src/lib/react/ReactDebugMacro.hx
+++ b/src/lib/react/ReactDebugMacro.hx
@@ -1,0 +1,132 @@
+package react;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+
+class ReactDebugMacro
+{
+	public static var firstRenderWarning:Bool = true;
+
+	#if macro
+	public static macro function buildComponent():Array<Field>
+	{
+		var pos = Context.currentPos();
+		var inClass = Context.getLocalClass().get();
+		var fields = Context.getBuildFields();
+
+		var propsType:ComplexType = macro :Dynamic;
+		var stateType:ComplexType = macro :Dynamic;
+
+		switch (inClass.superClass)
+		{
+			case {params: params, t: _.toString() => "react.ReactComponentOf"}:
+				propsType = TypeTools.toComplexType(params[0]);
+				stateType = TypeTools.toComplexType(params[1]);
+
+			default:
+		}
+
+		if (!updateComponentUpdate(fields, inClass, propsType, stateType))
+			addComponentUpdate(fields, inClass, propsType, stateType);
+
+		return fields;
+	}
+
+	static function updateComponentUpdate(
+		fields:Array<Field>,
+		inClass:ClassType,
+		propsType:ComplexType,
+		stateType:ComplexType
+	) {
+		for (field in fields)
+		{
+			if (field.name == "componentDidUpdate")
+			{
+				switch (field.kind) {
+					case FFun(f):
+						if (f.args.length != 2)
+							return Context.error('componentDidUpdate should accept two arguments', inClass.pos);
+
+						f.expr = macro {
+							${exprComponentDidUpdate(inClass, f.args[0].name, f.args[1].name)}
+							${f.expr}
+						};
+
+						return true;
+					default:
+				}
+			}
+		}
+
+		return false;
+	}
+
+	static function addComponentUpdate(
+		fields:Array<Field>,
+		inClass:ClassType,
+		propsType:ComplexType,
+		stateType:ComplexType
+	) {
+		var componentDidUpdate = {
+			args: [
+				{
+					meta: [],
+					name: "prevProps",
+					type: propsType,
+					opt: false,
+					value: null
+				},
+				{
+					meta: [],
+					name: "prevState",
+					type: stateType,
+					opt: false,
+					value: null
+				}
+			],
+			ret: macro :Void,
+			expr: exprComponentDidUpdate(inClass, "prevProps", "prevState")
+		}
+
+		fields.push({
+			name: 'componentDidUpdate',
+			access: [APublic, AOverride],
+			kind: FFun(componentDidUpdate),
+			pos: inClass.pos
+		});
+	}
+
+	static function exprComponentDidUpdate(inClass:ClassType, prevProps:String, prevState:String)
+	{
+		return macro {
+			var propsAreEqual = react.ReactUtil.shallowCompare(this.props, $i{prevProps});
+			var statesAreEqual = react.ReactUtil.shallowCompare(this.state, $i{prevState});
+
+			if (propsAreEqual && statesAreEqual)
+			{
+				// Using Object.create(null) to avoid prototype for clean output
+				var debugProps = untyped Object.create(null);
+				debugProps.currentProps = this.props;
+				debugProps.prevProps = $i{prevProps};
+
+				js.Browser.console.warn(
+					'Warning: avoidable re-render of `${$v{inClass.name}}`.\n',
+					debugProps
+				);
+
+				if (react.ReactDebugMacro.firstRenderWarning)
+				{
+					react.ReactDebugMacro.firstRenderWarning = false;
+
+					js.Browser.console.warn(
+						'Make sure your props are flattened, or implement shouldComponentUpdate.\n' +
+						'See https://facebook.github.io/react/docs/optimizing-performance.html#shouldcomponentupdate-in-action'
+					);
+				}
+			}
+		}
+	}
+	#end
+}


### PR DESCRIPTION
## Optimization tools

### Avoidable renders warning

Setting `-D react_render_warning` will enable runtime warnings for avoidable renders.

This will add a `componentDidUpdate` (or update the existing one) where a **shallowCompare** is done on current and previous props and state. If both did not change, a warning will be displayed in the console.

False positives can happen if your props are not flat, due to the shallowCompare.
