### PR TITLE
Changes in setState signature

### DIFF
--- a/src/lib/react/Partial.hx
+++ b/src/lib/react/Partial.hx
@@ -1,0 +1,43 @@
+/*
+	From a gist by George Corney:
+	https://gist.github.com/haxiomic/ad4f5d329ac616543819395f42037aa1
+*/
+package react;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.TypeTools;
+
+#if !macro
+@:genericBuild(react.PartialMacro.build())
+#end
+class Partial<T> {}
+
+class PartialMacro {
+	#if macro
+	static function build()
+	{
+		switch Context.getLocalType()
+		{
+			// Match when class's type parameter leads to an anonymous type (we convert to a complex type in the process to make it easier to work with)
+			case TInst(_, [Context.followWithAbstracts(_) => TypeTools.toComplexType(_) => TAnonymous(fields)]):
+				// Add @:optional meta to all fields
+				for (field in fields)
+				{
+					field.meta.push({
+						name: ':optional',
+						params: [],
+						pos: field.pos
+					});
+				}
+
+				return TAnonymous(fields);
+
+			default:
+				Context.fatalError('Type parameter should be an anonymous structure', Context.currentPos());
+		}
+
+		return null;
+	}
+	#end
+}

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -1,4 +1,5 @@
 package react;
+import haxe.extern.EitherType;
 
 typedef ReactComponentProps = {
 	/**
@@ -24,6 +25,7 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 @:native('React.Component')
 @:keepSub 
 @:autoBuild(react.ReactMacro.buildComponent())
+@:autoBuild(react.ReactTypeMacro.alterComponentSignatures())
 extern class ReactComponentOf<TProps, TState, TRefs>
 {
 	var props(default, null):TProps;
@@ -45,9 +47,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/react-component.html#setstate
 	**/
-	@:overload(function(nextState:TState -> TProps -> TState, ?callback:Void -> Void):Void {})
-	@:overload(function(nextState:TState -> TState, ?callback:Void -> Void):Void {})
-	function setState(nextState:TState, ?callback:Void -> Void):Void;
+	function setState(nextState:EitherType<TState -> TState, EitherType<TState -> TProps -> TState, TState>>, ?callback:Void -> Void):Void;
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#render

--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -1,0 +1,128 @@
+package react;
+
+import haxe.macro.ComplexTypeTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+
+class ReactTypeMacro
+{
+	#if macro
+	public static macro function alterComponentSignatures():Array<Field>
+	{
+		var inClass = Context.getLocalClass().get();
+		var fields = Context.getBuildFields();
+
+		var propsType:ComplexType = macro :Dynamic;
+		var stateType:ComplexType = macro :Dynamic;
+
+		switch (inClass.superClass)
+		{
+			case {params: params, t: _.toString() => 'react.ReactComponentOf'}:
+				propsType = TypeTools.toComplexType(params[0]);
+				stateType = TypeTools.toComplexType(params[1]);
+
+			default:
+		}
+
+		// Only alter setState signature for non-dynamic states
+		switch (ComplexTypeTools.toType(stateType))
+		{
+			case TType(_) if (!hasSetState(fields)):
+				addSetStateType(fields, inClass, propsType, stateType);
+
+			default:
+		}
+
+		return fields;
+	}
+
+	public static function getSetStateArgType(propsType:ComplexType, stateType:ComplexType)
+	{
+		var partialStateType = switch (ComplexTypeTools.toType(stateType)) {
+			case TType(_):
+				TPath({
+					name: 'Partial',
+					pack: ['react'],
+					params: [TPType(stateType)]
+				});
+
+			default:
+				macro :Dynamic;
+		}
+
+		return TPath({
+			name: 'EitherType',
+			pack: ['haxe', 'extern'],
+			params: [
+				TPType(TFunction([stateType], partialStateType)),
+				TPType(TPath({
+					name: 'EitherType',
+					pack: ['haxe', 'extern'],
+					params: [
+						TPType(TFunction([stateType, propsType], partialStateType)),
+						TPType(partialStateType)
+					]
+				}))
+			]
+		});
+	}
+
+	static function hasSetState(fields:Array<Field>) {
+		for (field in fields)
+		{
+			if (field.name == 'setState')
+			{
+				return switch (field.kind) {
+					case FFun(f): true;
+					default: false;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	static function addSetStateType(
+		fields:Array<Field>,
+		inClass:ClassType,
+		propsType:ComplexType,
+		stateType:ComplexType
+	) {
+		var setState = {
+			args: [
+				{
+					meta: [],
+					name: 'nextState',
+					type: getSetStateArgType(propsType, stateType),
+					opt: false,
+					value: null
+				},
+				{
+					meta: [],
+					name: 'callback',
+					type: macro :Void->Void,
+					opt: true,
+					value: null
+				}
+			],
+			ret: macro :Void,
+			expr: macro {super.setState(nextState, callback);}
+		};
+
+		fields.push({
+			name: 'setState',
+			access: [APublic, AOverride],
+			meta: [{
+				// Add @:extern meta so that this code only exist at compile time
+				name: ':extern',
+				params: null,
+				pos: inClass.pos
+			}],
+			kind: FFun(setState),
+			pos: inClass.pos
+		});
+	}
+	#end
+}


### PR DESCRIPTION
* Allow setState override by using `EitherType` instead of `@:overload`

* Allow setState with partial state
This is done by changing the signature of setState for every component having a state type other than Dynamic in order to use `Partial<TState>` instead of `TState`, using to [a gist](https://gist.github.com/haxiomic/ad4f5d329ac616543819395f42037aa1) by @haxiomic.