### PR TITLE
Updated PropTypes extern

### DIFF
--- a/src/lib/react/ReactPropTypes.hx
+++ b/src/lib/react/ReactPropTypes.hx
@@ -1,25 +1,58 @@
 package react;
 
+import haxe.extern.EitherType;
+import js.Error;
+import react.ReactComponent;
+
 /**
-	https://facebook.github.io/react/docs/top-level-api.html#react.proptypes
+	https://reactjs.org/docs/typechecking-with-proptypes.html
 **/
-@:jsRequire('react', 'PropTypes')
+#if (!react_global)
+@:jsRequire('prop-types')
+#end
+@:native('PropTypes')
 extern class ReactPropTypes
 {
-	static var array:Dynamic;
-	static var bool:Dynamic;
-	static var func:Dynamic;
-	static var number:Dynamic;
-	static var object:Dynamic;
-	static var string:Dynamic;
-	static var element:Dynamic;
-	static var any:Dynamic;
-	static var arrayOf:Dynamic;
-	static var DOMElement:Dynamic;
-	static var instanceOf:Dynamic;
-	static var node:Dynamic;
-	static var objectOf:Dynamic;
-	static var oneOf:Dynamic;
-	static var oneOfType:Dynamic;
-	static var shape:Dynamic;
+	static var any:ChainableTypeChecker;
+	static var array:ChainableTypeChecker;
+	static var bool:ChainableTypeChecker;
+	static var func:ChainableTypeChecker;
+	static var number:ChainableTypeChecker;
+	static var object:ChainableTypeChecker;
+	static var string:ChainableTypeChecker;
+	static var symbol:ChainableTypeChecker;
+	static var element:ChainableTypeChecker;
+	static var node:ChainableTypeChecker;
+
+	static var arrayOf:ArrayOfTypeChecker -> ChainableTypeChecker;
+	static var instanceOf:Class<ReactComponent> -> ChainableTypeChecker;
+	static var objectOf:ArrayOfTypeChecker -> ChainableTypeChecker;
+	static var oneOf:Array<Dynamic> -> ChainableTypeChecker;
+	static var oneOfType:Array<TypeChecker> -> ChainableTypeChecker;
+	static var shape:TypeShape->ChainableTypeChecker;
+	static var exact:TypeShape->ChainableTypeChecker;
+
+	static function checkPropTypes(
+		typeSpecs:Dynamic,
+		values:Dynamic,
+		location:PropTypesLocation,
+		componentName:String,
+		?getStack:Void -> Dynamic
+	):Dynamic;
+}
+
+typedef TypeChecker = EitherType<ChainableTypeChecker, CustomTypeChecker>;
+typedef ArrayOfTypeChecker = EitherType<ChainableTypeChecker, CustomArrayOfTypeChecker>;
+typedef CustomTypeChecker = Dynamic -> String -> String -> Null<Error>;
+typedef CustomArrayOfTypeChecker = Array<Dynamic> -> String -> String -> PropTypesLocation -> String -> Null<Error>;
+typedef TypeShape = Dynamic<TypeChecker>;
+
+@:enum abstract PropTypesLocation(String) from String {
+	var Prop = 'prop';
+	var Context = 'context';
+	var ChildContext = 'child context';
+}
+
+private typedef ChainableTypeChecker = {
+	@:optional var isRequired:Dynamic;
 }


### PR DESCRIPTION
I plan on working on auto implementation of propTypes for ReactComponents (opt-in with a compilation flag, only in debug mode), so I needed an updated version of the PropTypes extern.

I will create another PR for the "auto propTypes" feature when ready.

Can be tested with an adaptation from the official documentation [example](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes):

```haxe
import react.ReactPropTypes as PropTypes;

static var propTypes = {
	// You can declare that a prop is a specific JS primitive. By default, these
	// are all optional.
	optionalArray: PropTypes.array,
	optionalBool: PropTypes.bool,
	optionalFunc: PropTypes.func,
	optionalNumber: PropTypes.number,
	optionalObject: PropTypes.object,
	optionalString: PropTypes.string,
	optionalSymbol: PropTypes.symbol,

	// Anything that can be rendered: numbers, strings, elements or an array
	// (or fragment) containing these types.
	optionalNode: PropTypes.node,

	// A React element.
	optionalElement: PropTypes.element,

	// You can also declare that a prop is an instance of a class. This uses
	// JS's instanceof operator.
	optionalMessage: PropTypes.instanceOf(Link),

	// You can ensure that your prop is limited to specific values by treating
	// it as an enum.
	optionalEnum: PropTypes.oneOf(['News', 'Photos']),

	// An object that could be one of many types
	optionalUnion: PropTypes.oneOfType([
		PropTypes.string,
		PropTypes.number,
		PropTypes.instanceOf(Link)
	]),

	// An array of a certain type
	optionalArrayOf: PropTypes.arrayOf(PropTypes.number),

	// An object with property values of a certain type
	optionalObjectOf: PropTypes.objectOf(PropTypes.number),

	// An object taking on a particular shape
	optionalObjectWithShape: PropTypes.shape({
		color: PropTypes.string,
		fontSize: PropTypes.number
	}),

	// You can chain any of the above with `isRequired` to make sure a warning
	// is shown if the prop isn't provided.
	requiredFunc: PropTypes.func.isRequired,

	// A value of any data type
	requiredAny: PropTypes.any.isRequired,

	// You can also specify a custom validator. It should return an Error
	// object if the validation fails. Don't `console.warn` or throw, as this
	// won't work inside `oneOfType`.
	customProp: function(props, propName, componentName) {
		if (!~/matchme/.match(Reflect.field(props, propName))) {
			return new Error(
				'Invalid prop `' + propName + '` supplied to' +
				' `' + componentName + '`. Validation failed.'
			);
		}

		return null;
	},

	// You can also supply a custom validator to `arrayOf` and `objectOf`.
	// It should return an Error object if the validation fails. The validator
	// will be called for each key in the array or object. The first two
	// arguments of the validator are the array or object itself, and the
	// current item's key.
	customArrayProp: PropTypes.arrayOf(function(propValue, key, componentName, location, propFullName) {
		if (!~/matchme/.match(Reflect.field(propValue, key))) {
			return new Error(
				'Invalid prop `' + propFullName + '` supplied to' +
				' `' + componentName + '`. Validation failed.'
			);
		}

		return null;
	})
}
```