### PR TITLE
#84 - add displayName for @:jsxStatic components

### DIFF
--- a/src/lib/react/JsxStaticMacro.hx
+++ b/src/lib/react/JsxStaticMacro.hx
@@ -1,0 +1,138 @@
+package react;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import react.ReactMacro.extractMetaString;
+
+using haxe.macro.Tools;
+
+private typedef JsxStaticDecl = {
+	var module:String;
+	var className:String;
+	var displayName:String;
+	var fieldName:String;
+}
+
+class JsxStaticMacro
+{
+	static public var META_NAME = ':jsxStatic';
+
+	static var hasBeenHooked = false;
+	static var decls:Array<JsxStaticDecl> = [];
+
+	static public function injectDisplayNames(type:Expr)
+	{
+		#if !debug
+		return;
+		#end
+
+		// Add hook to generate __init__ at the end of the compilation
+		if (!hasBeenHooked)
+		{
+			hasBeenHooked = true;
+			Context.onAfterTyping(afterTypingHook);
+		}
+
+		switch (Context.typeExpr(type).expr) {
+			case TConst(TString(_)):
+				// HTML component, nothing to do
+
+			case TTypeExpr(TClassDecl(_)):
+				// ReactComponent, should already handle its displayName
+
+			case TField(_, FStatic(clsTypeRef, _.get() => {kind: FMethod(_), name: fieldName})):
+				var clsType = clsTypeRef.get();
+				var displayName = handleJsxStaticMeta(clsType, fieldName);
+
+				addDisplayNameDecl({
+					module: clsType.module,
+					className: clsType.name,
+					displayName: displayName,
+					fieldName: fieldName
+				});
+
+			case TCall({expr: TField(_, FStatic(clsTypeRef, clsField))}, _):
+				var clsType = clsTypeRef.get();
+				var fieldName = clsField.get().name;
+				var displayName = StringTools.startsWith(fieldName, 'get_')
+					? handleJsxStaticMeta(clsType, fieldName.substr(4))
+					: fieldName;
+
+				addDisplayNameDecl({
+					module: clsType.module,
+					className: clsType.name,
+					displayName: displayName,
+					fieldName: fieldName
+				});
+
+			case TLocal({name: varName}):
+				// Local vars not handled at the moment
+			
+			case TField(_, FInstance(_, _, _)):
+				// Instance fields not handled at the moment
+			
+			case TField(_, FStatic(_, _)):
+				// Static variables not handled at the moment
+
+			default:
+				// Unknown type, not handled
+				// trace(typedExpr);
+		}
+	}
+
+	static function handleJsxStaticMeta(clsType:ClassType, displayName:String)
+	{
+		var jsxStatic = extractMetaString(clsType.meta, META_NAME);
+		if (jsxStatic != null && jsxStatic == displayName) return clsType.name;
+		return displayName;
+	}
+
+	static function addDisplayNameDecl(decl:JsxStaticDecl)
+	{
+		var previousDecl = Lambda.find(decls, function(d) {
+			return d.module == decl.module
+				&& d.className == decl.className
+				&& d.fieldName == decl.fieldName;
+		});
+
+		if (previousDecl == null) decls.push(decl);
+	}
+
+	static function afterTypingHook(modules:Array<ModuleType>)
+	{
+		var initModule = "JsxStaticInit__";
+
+		try {
+			// Could also loop through modules, but it's easier like this
+			Context.getModule(initModule);
+		} catch(e:Dynamic) {
+			var exprs = decls.map(function(decl) {
+				var fName = decl.fieldName;
+				return macro {
+					untyped $i{decl.className}.$fName.displayName = 
+					$i{decl.className}.$fName.displayName || $v{decl.displayName};
+				};
+			});
+
+			var cls = macro class $initModule {
+				static function __init__() {
+					$a{exprs};
+				}
+			};
+
+			var imports = decls.map(function(decl) return generatePath(decl.module));
+			Context.defineModule(initModule, [cls], imports);
+		}
+	}
+
+	static function generatePath(module:String)
+	{
+		var parts = module.split('.');
+
+		return {
+			mode: ImportMode.INormal,
+			path: parts.map(function(part) return {pos: (macro null).pos, name: part})
+		};
+	}
+}

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -105,6 +105,7 @@ class ReactMacro
 
 				// inline declaration or createElement?
 				var typeInfo = getComponentInfo(type);
+				JsxStaticMacro.injectDisplayNames(type);
 				var useLiteral = canUseLiteral(typeInfo, ref);
 				if (useLiteral)
 				{
@@ -265,7 +266,7 @@ class ReactMacro
 		}
 	}
 
-	static function extractMetaString(meta:MetaAccess, name:String):String
+	public static function extractMetaString(meta:MetaAccess, name:String):String
 	{
 		if (!meta.has(name)) return null;
 

--- a/src/lib/react/jsx/JsxStaticMacro.hx
+++ b/src/lib/react/jsx/JsxStaticMacro.hx
@@ -1,9 +1,8 @@
-package react;
+package react.jsx;
 
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
-import react.ReactMacro.extractMetaString;
 
 using haxe.macro.Tools;
 
@@ -79,6 +78,36 @@ class JsxStaticMacro
 				// Unknown type, not handled
 				// trace(typedExpr);
 		}
+	}
+
+	static public function handleJsxStaticProxy(type:Expr)
+	{
+		var typedExpr = Context.typeExpr(type);
+
+		switch (typedExpr.expr)
+		{
+			case TTypeExpr(TClassDecl(_.get() => c)):
+				if (c.meta.has(META_NAME))
+					type.expr = EField(
+						{expr: EConst(CIdent(c.name)), pos: type.pos},
+						extractMetaString(c.meta, META_NAME)
+					);
+
+			default:
+		}
+	}
+
+	static function extractMetaString(meta:MetaAccess, name:String):String
+	{
+		if (!meta.has(name)) return null;
+
+		var metas = meta.extract(name);
+		if (metas.length == 0) return null;
+
+		var params = metas.pop().params;
+		if (params.length == 0) return null;
+
+		return params.pop().getValue();
 	}
 
 	static function handleJsxStaticMeta(clsType:ClassType, displayName:String)


### PR DESCRIPTION
When compiled with `-debug`, add a displayName to functional components for use with external tools (enzyme, chrome dev tools, etc.).

Handled components include:
* Component classes with @:jsxStatic meta
* Static methods returning a ReactElement
* Static variables with getter returning a ReactElement

Local vars, static vars (without getter) & instance fields are not handled -- they will still be displayed as "Unknown". It's because they are not constant so it's a lot more complex.

Output example, at the end of the generated js file:
```javascript
components_Footer.render.displayName = components_Footer.render.displayName || "Footer";
```

This should be compatible with haxe-modular code splitting, but this has not been tested yet (I need to setup a sample project).

Cleanup: moved all jsxStatic-related code to `react.jsx.JsxStaticMacro.hx`