### PR TITLE
Add support for react 16.2.0 fragments

### DIFF
--- a/src/lib/react/Fragment.hx
+++ b/src/lib/react/Fragment.hx
@@ -1,0 +1,20 @@
+package react;
+
+/**
+	Warning: Fragments are only available in react 16.2.0+
+	https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html
+**/
+@:native('React.Fragment')
+extern class Fragment extends ReactComponent {
+	#if debug
+	static function __init__():Void
+	{
+		var version = react.React.version.split('.')
+			.filter(function(s) return s != '.')
+			.map(untyped parseInt);
+		
+		if (version[0] < 16 || version[0] == 16 && version[1] < 2)
+			js.Browser.console.warn('Fragments are not available on react < 16.2.0');
+	}
+	#end
+}

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -32,6 +32,8 @@ extern class React
 		https://facebook.github.io/react/docs/react-api.html#react.children
 	**/
 	public static var Children:ReactChildren;
+
+	public static var version:String;
 }
 
 /**

--- a/src/lib/react/jsx/JsxSanitize.hx
+++ b/src/lib/react/jsx/JsxSanitize.hx
@@ -114,9 +114,11 @@ class JsxSanitize
 			
 			// xml tags
 			if (inTag) {
-				if  (ci == '>') inTag = false;
+				if (ci == '>') inTag = false;
 			}
 			else if (ci == '<') {
+				if (cn == '>') ci = '<react.Fragment';
+				else if (cn == '/' && chars[i + 1] == '>') cn = '/react.Fragment';
 				inTag = true;
 			}
 			buf.add(ci);

--- a/test/src/JsxSanitizeTest.hx
+++ b/test/src/JsxSanitizeTest.hx
@@ -114,4 +114,11 @@ class JsxSanitizeTest
 		var jsx = ReactMacro.sanitize('<Tag a="a" {...foo} b="b"/>');
 		Assert.areEqual("<Tag a=\"a\" .0=\"{foo}\" b=\"b\"/>", jsx);
 	}
+
+	@Test
+	public function sanitize_replaces_empty_tags_with_fragments()
+	{
+		var jsx = ReactMacro.sanitize('<>Text</>');
+		Assert.areEqual("<react.Fragment>Text</react.Fragment>", jsx);
+	}
 }


### PR DESCRIPTION
#85 -- see https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html

Allows both:
```jsx
<Fragment>
	Text
	<span>more text</span>
	Still more text
</Fragment>
```

and:
```jsx
<>
	Text
	<span>more text</span>
	Still more text
</>
```

Will display a runtime warning if used with react < 16.2.0 (only if compiled with `-debug`).

Implementation of `≤> ... </>` syntax is a little hacky... if you have any suggestion I would gladly change it.