### PR TITLE
@:pure for PureComponent + changes to ReactComponent

### DIFF
--- a/src/lib/react/PureComponentMacro.hx
+++ b/src/lib/react/PureComponentMacro.hx
@@ -1,0 +1,122 @@
+package react;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+
+class PureComponentMacro
+{
+	static public function build(inClass:ClassType, fields:Array<Field>)
+	{
+		if (getField(fields, 'shouldComponentUpdate') == null) {
+			var propsType:ComplexType = macro :Dynamic;
+			var stateType:ComplexType = macro :Dynamic;
+
+			switch (inClass.superClass)
+			{
+				case {params: params, t: _.toString() => 'react.ReactComponentOf'}:
+					propsType = TypeTools.toComplexType(params[0]);
+					stateType = TypeTools.toComplexType(params[1]);
+
+				default:
+			}
+
+			var hasProps = !isTVoid(propsType);
+			var hasState = !isTVoid(stateType);
+
+			var shouldUpdateExpr:Expr = null;
+
+			if (hasProps && hasState)
+				shouldUpdateExpr = exprShouldUpdatePropsAndState();
+			else if (hasProps)
+				shouldUpdateExpr = exprShouldUpdateProps();
+			else if (hasState)
+				shouldUpdateExpr = exprShouldUpdateState();
+			else
+				shouldUpdateExpr = exprShouldNeverUpdate();
+
+			addShouldUpdate(fields, propsType, stateType, shouldUpdateExpr);
+		}
+
+		return fields;
+	}
+
+	static public function getField(fields:Array<Field>, name:String)
+	{
+		for (field in fields)
+			if (field.name == name)
+				return field;
+
+		return null;
+	}
+
+	static function isTVoid(type:ComplexType)
+	{
+		return switch (type) {
+			case TPath({
+				name: 'ReactComponent',
+				pack: ['react'],
+				params: [],
+				sub: 'TVoid'
+			}): true;
+
+			default: false;
+		};
+	}
+
+	static function addShouldUpdate(
+		fields:Array<Field>,
+		propsType:ComplexType,
+		stateType:ComplexType,
+		shouldUpdateExpr:Expr
+	) {
+		var args:Array<FunctionArg> = [
+			{name: 'nextProps', type: propsType, opt: false, value: null},
+			{name: 'nextState', type: stateType, opt: false, value: null}
+		];
+
+		var fun = {
+			args: args,
+			ret: macro :Bool,
+			expr: shouldUpdateExpr
+		};
+
+		fields.push({
+			name: 'shouldComponentUpdate',
+			access: [APublic, AOverride],
+			kind: FFun(fun),
+			pos: Context.currentPos()
+		});
+	}
+
+	static function exprShouldNeverUpdate()
+	{
+		return macro {
+			return false;
+		};
+	}
+
+	static function exprShouldUpdateProps()
+	{
+		return macro {
+			return !react.ReactUtil.shallowCompare(props, nextProps);
+		};
+	}
+
+	static function exprShouldUpdateState()
+	{
+		return macro {
+			return !react.ReactUtil.shallowCompare(state, nextState);
+		};
+	}
+
+	static function exprShouldUpdatePropsAndState()
+	{
+		return macro {
+			return !react.ReactUtil.shallowCompare(state, nextState)
+				|| !react.ReactUtil.shallowCompare(props, nextProps);
+		};
+	}
+}
+

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -12,13 +12,20 @@ typedef ReactComponentProps = {
 /**
 	https://facebook.github.io/react/docs/react-component.html
 **/
-typedef ReactComponent = ReactComponentOf<Dynamic, Dynamic, Dynamic>;
-typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Dynamic, Dynamic>;
-typedef ReactComponentOfState<TState> = ReactComponentOf<Dynamic, TState, Dynamic>;
-typedef ReactComponentOfRefs<TRefs> = ReactComponentOf<Dynamic, Dynamic, TRefs>;
-typedef ReactComponentOfStateAndRefs<TState, TRefs> = ReactComponentOf<Dynamic, TState, TRefs>;
-typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState, Dynamic>;
-typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, Dynamic, TRefs>;
+typedef ReactComponent = ReactComponentOf<Dynamic, Dynamic>;
+
+#if react_comp_strict_typing
+enum TVoid {}
+typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, TVoid>;
+typedef ReactComponentOfState<TState> = ReactComponentOf<TVoid, TState>;
+#else
+typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Dynamic>;
+typedef ReactComponentOfState<TState> = ReactComponentOf<Dynamic, TState>;
+#end
+
+#if react_comp_legacy
+typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState>;
+#end
 
 #if (!react_global)
 @:jsRequire("react", "Component")
@@ -30,16 +37,11 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 #if (debug && react_render_warning)
 @:autoBuild(react.ReactDebugMacro.buildComponent())
 #end
-extern class ReactComponentOf<TProps, TState, TRefs>
+extern class ReactComponentOf<TProps, TState>
 {
 	var props(default, null):TProps;
 	var state(default, null):TState;
 	var context(default, null):Dynamic;
-
-	/**
-		https://facebook.github.io/react/docs/refs-and-the-dom.html
-	**/
-	var refs(default, null):TRefs;
 
 	function new(?props:TProps, ?context:Dynamic);
 

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -59,6 +59,7 @@ class ReactMacro
 				Context.fatalError('Invalid JSX: ' + err, err.pos ? err.pos : pos);
 
 		var ast = JsxParser.process(xml);
+		if (ast == null) return macro null;
 		var expr = parseJsxNode(ast, pos);
 		return expr;
 	}

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -290,6 +290,9 @@ class ReactMacro
 		storeComponentInfos(fields, inClass, pos);
 		#end
 
+		if (inClass.meta.has(":pure"))
+			PureComponentMacro.build(inClass, fields);
+
 		if (!inClass.isExtern)
 			tagComponent(fields, inClass, pos);
 


### PR DESCRIPTION
### Warning: this contains breaking changes

I started by removing string refs from `ReactComponent`, this api being considered "legacy" or even deprecated (by eslint at least).

This is the breaking change of this PR, since even if a project never uses `ReactComponentOfRefs` and such, `ReactComponentOfPropsAndState` has been removed in favor of just `ReactComponentOf<TProps, TState>`.

`ReactComponentOfPropsAndState` can be reactivated by using the `react_comp_legacy` compilation flag. `ReactComponentOfRefs` and such cannot be reactivated.

### Optional behavior: strict ReactComponentOf typing

One source of errors I have found in haxe-react projects, is having a `ReactComponentOfProps` and doing things with the state, which has then no typing (`Dynamic`) and can lead to disturbing code (the component appears to have no state, while in practice it has one).

I added, under the `react_comp_strict_typing` compilation flag, a simple fix to that: `ReactComponentOfProps` use `TVoid` as TState, and `ReactComponentOfState` use it as TProps. `TVoid` is an empty enum, so manipulating state on a ReactComponentOfProps should become impossible, as well as accessing props.

I can see one con with this feature: you'll need to have a TProps if you want to use `props.children`. **Maybe exposing children via a getter (in ReactComponent) returning `untyped props.children` could help here?** (and in other cases when we use children and do not want to add it to our TProps)

### Original feature of this PR: `@:pure`

Note: **maybe use `@:pureComponent` instead to avoid conflict with other features?**

The original purpose of this PR was to add support for PureComponents making use of haxe-react knowledge of our components. The previous points were just things I had in mind for a few months and having them simplified the work for this feature.

Adding a `@:pure` meta to your component class, a `shouldComponentUpdate` will be added. The content of this function will depend on your TProps and TState:
 * If both TProps and TState are defined (not TVoid), this will have the same behavior as React's PureComponent (shallowCompare on both props and state)
 * If only TProps or TState is defined, only the props (resp. the state) will be shallowCompare'd
 * If somehow you have both TProps and TState being TVoid, the function will always return false without checking anything

Note that it will only be added if you haven't defined one yourself; **should it break instead of doing nothing, with a compilation error/warning stating that this `@:pure` didn't do anything?**

### Notes

 * This PR should at least be updated by adding documentation to the README file about those changes.
 * This includes a [small commit](https://github.com/massiveinteractive/haxe-react/commit/d679eb39fb03c966140abe6c96eac9a9bc92589f) I had in my local version for handling `jsx('')` (with empty string) without breaking with an unclear error message.