### PR TITLE
Opt-in strict typing for TProps/TState and jsx

### DIFF
--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -11,13 +11,22 @@ typedef ReactComponentProps = {
 /**
 	https://facebook.github.io/react/docs/react-component.html
 **/
-typedef ReactComponent = ReactComponentOf<Dynamic, Dynamic, Dynamic>;
-typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Dynamic, Dynamic>;
-typedef ReactComponentOfState<TState> = ReactComponentOf<Dynamic, TState, Dynamic>;
-typedef ReactComponentOfRefs<TRefs> = ReactComponentOf<Dynamic, Dynamic, TRefs>;
-typedef ReactComponentOfStateAndRefs<TState, TRefs> = ReactComponentOf<Dynamic, TState, TRefs>;
-typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState, Dynamic>;
-typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, Dynamic, TRefs>;
+typedef ReactComponent = ReactComponentOf<Dynamic, Dynamic>;
+
+typedef TVoid = {}
+enum EVoid {}
+
+#if react_strict_typing
+typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, EVoid>;
+typedef ReactComponentOfState<TState> = ReactComponentOf<TVoid, TState>;
+#else
+typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Dynamic>;
+typedef ReactComponentOfState<TState> = ReactComponentOf<Dynamic, TState>;
+#end
+
+#if react_comp_legacy
+typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState>;
+#end
 
 #if (!react_global)
 @:jsRequire("react", "Component")
@@ -29,16 +38,11 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 #if (debug && react_render_warning)
 @:autoBuild(react.ReactDebugMacro.buildComponent())
 #end
-extern class ReactComponentOf<TProps, TState, TRefs>
+extern class ReactComponentOf<TProps, TState>
 {
 	var props(default, null):TProps;
 	var state(default, null):TState;
 	var context(default, null):Dynamic;
-
-	/**
-		https://facebook.github.io/react/docs/refs-and-the-dom.html
-	**/
-	var refs(default, null):TRefs;
 
 	function new(?props:TProps, ?context:Dynamic);
 

--- a/src/lib/react/ReactUtil.hx
+++ b/src/lib/react/ReactUtil.hx
@@ -95,4 +95,19 @@ class ReactUtil
 				return false;
 		return true;
 	}
+
+	public static inline function checkFunPropsType<TProps>(
+		fun:TProps->haxe.extern.EitherType<ReactElement, Array<ReactElement>>,
+		props:TProps
+	):Void {}
+
+	public static inline function checkFunNoPropsType(
+		fun:Void->haxe.extern.EitherType<ReactElement, Array<ReactElement>>,
+		props:EVoid
+	):Void {}
+
+	public static inline function checkCompPropsType<TProps, TState>(
+		component:Class<ReactComponentOf<TProps, TState>>,
+		props:TProps
+	):Void {}
 }


### PR DESCRIPTION
Implemented opt-in strict typing for haxe-react components.

This has an advantage over PropTypes in that it is compile-time, and will always let you know when you misuse a component, even if this component rarely appears at runtime.

This is opt-in (for now?), as I think many projects wouldn't compile any more at first due to imprecise or incomplete TProps in some components.

Components (classes extending ReactComponent), `@:jsxStatic` components and functional components (functions accepting props as argument (or no argument at all)) are handled.

It is perfectible but functional. Some things that will need to be improved in the future:

 * Better errors, at least with a more precise position (the error is on the whole jsx, and would need another jsx parser to be able to point at the jsx node). Example errors:
   ```
   Object requires field missingProp
   For function argument 'props'

   { onClick : Void -> Void } has extra field onClick
   For function argument 'props'
   ```

 * Real type check on props.children. At the moment, when a component has `children` in their TProps, type checking is done with a value of `null` for children.

### Compiling with `-D react_strict_typing` will change a few things:

 *  `ReactComponentOfProps` will have a `TState` of `EVoid`, which is an empty enum that will hold no value at all, rendering usage of state impossible in these components (which should not have any state).

 * `ReactComponentOfState` will have a `TProps` of `TVoid`, which is an empty typedef that will accept any field but won't let you access `this.props.XX`.

 * Combined with `-debug`:
    * Props will be checked in jsx, leading to compile-time errors when you have props either missing, unneeded or with wrong type.

    * Some components or containers accept props that they do not know about, only to pass them to child components. Their definition is therefore not included in their own TProps. You can skip type checking on a per-prop basis by prefixing them with a colon: `<$MyComponent :otherprop="prop" />`.

### Added helpers

The trick used in this PR is to call empty functions with strict typing, providing them the component and the props we will be sending it. This cannot be replaced by testing unification in the macro itself, since the types are not fully available when the macro is executed.

Using "post-macro" empty functions ensures that all typing is done before, and has no impact on generated code.

The functions are available for other tools, but can only be useful for macros since they do nothing except checking the type of their arguments:
 * `ReactUtil.checkCompPropsType` for checking component + props
 * `ReactUtil.checkFunPropsType` for checking functional components + props
 * `ReactUtil.checkFunNoPropsType` for checking functional components accepting no props + props used in jsx (which should be empty). This one may be harder to make use of outside this PR.

### Note: includes a breaking change

This PR removes the deprecated string refs api, and thus removes `ReactComponentOfRefs`, `ReactComponentOfStateAndRefs`, and `ReactComponentOfPropsAndRefs`.

`ReactComponentOf` now only takes two params (`TProps` and `TState`), and replaces `ReactComponentOfPropsAndState`. The later can be reactivated (for now) by compiling with `-D react_comp_legacy`.

This can be removed from the PR if needed.