### PR TITLE
Added ReactUtil.copyWithout()

### DIFF
--- a/src/lib/react/ReactUtil.hx
+++ b/src/lib/react/ReactUtil.hx
@@ -47,6 +47,19 @@ class ReactUtil
 		return target;
 	}
 
+	public static function copyWithout(source1:Dynamic, source2:Dynamic, fields:Array<String>)
+	{
+		var target = {};
+		for (field in Reflect.fields(source1))
+			if (!Lambda.has(fields, field))
+				Reflect.setField(target, field, Reflect.field(source1, field));
+		if (source2 != null)
+			for (field in Reflect.fields(source2))
+				if (!Lambda.has(fields, field))
+					Reflect.setField(target, field, Reflect.field(source2, field));
+		return target;
+	}
+
 	public static function mapi<A, B>(items:Array<A>, map:Int -> A -> B):Array<B>
 	{
 		if (items == null) return null;


### PR DESCRIPTION
Can be useful for removing things like `children` from props before passing it to another component (via `React.cloneElement`, for example).

I use it on some react projects and it's needed by an incoming haxe-redux PR.