### PR TITLE
Pluggable ReactComponent build macros

### DIFF
--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -24,11 +24,7 @@ typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, D
 #end
 @:native('React.Component')
 @:keepSub
-@:autoBuild(react.ReactMacro.buildComponent())
-@:autoBuild(react.ReactTypeMacro.alterComponentSignatures())
-#if (debug && react_render_warning)
-@:autoBuild(react.ReactDebugMacro.buildComponent())
-#end
+@:autoBuild(react.ReactComponentMacro.build())
 extern class ReactComponentOf<TProps, TState, TRefs>
 {
 	var props(default, null):TProps;

--- a/src/lib/react/ReactComponentMacro.hx
+++ b/src/lib/react/ReactComponentMacro.hx
@@ -1,0 +1,35 @@
+package react;
+
+#if macro
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+
+typedef Builder = ClassType -> Array<Field> -> Array<Field>;
+
+class ReactComponentMacro {
+	static var builders:Array<Builder> = [
+		react.ReactMacro.buildComponent,
+		react.ReactTypeMacro.alterComponentSignatures,
+
+		#if (debug && react_render_warning)
+		react.ReactDebugMacro.buildComponent,
+		#end
+	];
+
+	static public function appendBuilder(builder:Builder):Void builders.push(builder);
+	static public function prependBuilder(builder:Builder):Void builders.unshift(builder);
+
+	static public function build():Array<Field>
+	{
+		var inClass = Context.getLocalClass().get();
+
+		return Lambda.fold(
+			builders,
+			function(builder, fields) return builder(inClass, fields),
+			Context.getBuildFields()
+		);
+	}
+}
+#end
+

--- a/src/lib/react/ReactDebugMacro.hx
+++ b/src/lib/react/ReactDebugMacro.hx
@@ -10,12 +10,9 @@ class ReactDebugMacro
 	public static var firstRenderWarning:Bool = true;
 
 	#if macro
-	public static macro function buildComponent():Array<Field>
+	public static function buildComponent(inClass:ClassType, fields:Array<Field>):Array<Field>
 	{
 		var pos = Context.currentPos();
-		var inClass = Context.getLocalClass().get();
-		var fields = Context.getBuildFields();
-
 		var propsType:ComplexType = macro :Dynamic;
 		var stateType:ComplexType = macro :Dynamic;
 

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -283,11 +283,9 @@ class ReactMacro
 	/**
 	 * Process React components
 	 */
-	public static macro function buildComponent():Array<Field>
+	public static function buildComponent(inClass:ClassType, fields:Array<Field>):Array<Field>
 	{
 		var pos = Context.currentPos();
-		var inClass = Context.getLocalClass().get();
-		var fields = Context.getBuildFields();
 
 		#if (!debug && !react_no_inline)
 		storeComponentInfos(fields, inClass, pos);

--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -9,11 +9,8 @@ import haxe.macro.TypeTools;
 class ReactTypeMacro
 {
 	#if macro
-	public static macro function alterComponentSignatures():Array<Field>
+	public static function alterComponentSignatures(inClass:ClassType, fields:Array<Field>):Array<Field>
 	{
-		var inClass = Context.getLocalClass().get();
-		var fields = Context.getBuildFields();
-
 		var propsType:ComplexType = macro :Dynamic;
 		var stateType:ComplexType = macro :Dynamic;
 


### PR DESCRIPTION
Allows other libs (haxe-redux, for example) to easily plug build macros to ReactComponent, for example to add behavior based on the component meta.