### PR TITLE
Unit test fixes

### DIFF
--- a/test/src/AssertTools.hx
+++ b/test/src/AssertTools.hx
@@ -1,0 +1,22 @@
+import haxe.macro.Expr;
+import massive.munit.Assert;
+
+class AssertTools
+{
+	macro static public function assertHasProps(oExpr:Expr, namesExpr:ExprOf<Array<String>>, ?valuesExpr:ExprOf<Array<Dynamic>>)
+	{
+		return macro {
+			var o:Dynamic = ${oExpr}, names:Array<String> = ${namesExpr}, values:Array<Dynamic> = ${valuesExpr};
+			var props = Reflect.fields(o);
+			Assert.areEqual(names.length, props.length);
+			for (i in 0...names.length)
+			{
+				var name = names[i];
+				Assert.areNotEqual( -1, props.indexOf(name));
+				if (values != null && values[i] != null)
+					Assert.areEqual(values[i], Reflect.field(o, name));
+			}
+		}
+	}
+
+}

--- a/test/src/ReactMacroTest.hx
+++ b/test/src/ReactMacroTest.hx
@@ -5,10 +5,11 @@ import react.ReactComponent;
 import react.ReactMacro.jsx;
 import support.sub.CompExternModule;
 import support.sub.CompModule;
+import AssertTools.assertHasProps;
 
-class CompBasic extends ReactComponent {	
+class CompBasic extends ReactComponent {
 }
-class CompDefaults extends ReactComponent {	
+class CompDefaults extends ReactComponent {
 	static public var defaultProps = {
 		defA:'A',
 		defB:42
@@ -22,78 +23,78 @@ class ReactMacroTest
 {
 
 	public function new() {}
-	
+
 	@BeforeClass
 	public function setup()
 	{
-		untyped window.CompExtern = function() {};
-		untyped window.CompExternModule = function() {};
+		untyped __js__("$global.CompExtern = function() {}");
+		untyped __js__("$global.CompExternModule = function() {}");
 	}
 
 	@Test
-	public function DOM_without_props() 
+	public function DOM_without_props()
 	{
 		var e = jsx('<div/>');
 		Assert.areEqual('div', e.type);
 		assertHasProps(e.props, []);
 	}
-	
+
 	@Test
-	public function DOM_with_const_props() 
+	public function DOM_with_const_props()
 	{
 		var e = jsx('<div a="foo" />');
 		Assert.areEqual('div', e.type);
 		assertHasProps(e.props, ['a'], ['foo']);
 	}
-	
+
 	@Test
-	public function DOM_with_const_and_binding_props() 
+	public function DOM_with_const_and_binding_props()
 	{
 		var foo = 12;
 		var e = jsx('<div a="foo" b=$foo />');
 		Assert.areEqual('div', e.type);
-		assertHasProps(e.props, ['a', 'b'], ['foo', 12]);
+		assertHasProps(e.props, ['a', 'b'], (['foo', 12]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function function_with_props() 
+	public function function_with_props()
 	{
 		var e = jsx('<RenderFunction a="foo" />');
 		Assert.areEqual(RenderFunction, e.type);
 		assertHasProps(e.props, ['a'], ['foo']);
 	}
-	
+
 	@Test
-	public function component_with_props() 
+	public function component_with_props()
 	{
 		var e = jsx('<CompBasic a="foo" />');
 		Assert.areEqual(CompBasic, e.type);
 		assertHasProps(e.props, ['a'], ['foo']);
 	}
-	
+
 	@Test
-	public function extern_component_qualified_module_should_DEOPT() 
+	public function extern_component_qualified_module_should_DEOPT()
 	{
 		var e = jsx('<support.sub.CompExternModule />');
 		Assert.areEqual('NATIVE', e.type);
 	}
-	
+
 	@Test
-	public function extern_component_module_should_DEOPT() 
+	public function extern_component_module_should_DEOPT()
 	{
 		var e = jsx('<CompExternModule />');
 		Assert.areEqual('NATIVE', e.type);
 	}
-	
+
 	@Test
-	public function extern_component_should_DEOPT() 
+	public function extern_component_should_DEOPT()
 	{
 		var e = jsx('<CompExtern />');
 		Assert.areEqual('NATIVE', e.type);
 	}
-	
+
 	@Test
-	public function DOM_with_spread() 
+	public function DOM_with_spread()
 	{
 		var o = {
 			a:'foo',
@@ -101,11 +102,11 @@ class ReactMacroTest
 		}
 		var e = jsx('<div {...o} />');
 		Assert.areEqual('div', e.type);
-		assertHasProps(e.props, ['a', 'b'], ['foo', 12]);
+		assertHasProps(e.props, ['a', 'b'], (['foo', 12]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function DOM_with_spread_and_prop() 
+	public function DOM_with_spread_and_prop()
 	{
 		var o = {
 			a:'foo',
@@ -113,11 +114,11 @@ class ReactMacroTest
 		}
 		var e = jsx('<div {...o} c="bar" />');
 		Assert.areEqual('div', e.type);
-		assertHasProps(e.props, ['a', 'b', 'c'], ['foo', 12, 'bar']);
+		assertHasProps(e.props, ['a', 'b', 'c'], (['foo', 12, 'bar']:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function DOM_with_spread_and_prop_override() 
+	public function DOM_with_spread_and_prop_override()
 	{
 		var o = {
 			a:'foo',
@@ -125,35 +126,35 @@ class ReactMacroTest
 		}
 		var e = jsx('<div {...o} a="bar" />');
 		Assert.areEqual('div', e.type);
-		assertHasProps(e.props, ['a', 'b'], ['bar', 12]);
+		assertHasProps(e.props, ['a', 'b'], (['bar', 12]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function component_with_defaultProps() 
+	public function component_with_defaultProps()
 	{
 		var e = jsx('<CompDefaults />');
 		Assert.areEqual(CompDefaults, e.type);
-		assertHasProps(e.props, ['defA', 'defB'], ['A', 42]);
+		assertHasProps(e.props, ['defA', 'defB'], (['A', 42]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function component_in_sub_package_with_defaultProps() 
+	public function component_in_sub_package_with_defaultProps()
 	{
 		var e = jsx('<CompModule />');
 		Assert.areEqual(CompModule, e.type);
-		assertHasProps(e.props, ['defA', 'defB'], ['B', 43]);
+		assertHasProps(e.props, ['defA', 'defB'], (['B', 43]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function qualified_component_in_sub_package_with_defaultProps() 
+	public function qualified_component_in_sub_package_with_defaultProps()
 	{
 		var e = jsx('<support.sub.CompModule />');
 		Assert.areEqual(CompModule, e.type);
-		assertHasProps(e.props, ['defA', 'defB'], ['B', 43]);
+		assertHasProps(e.props, ['defA', 'defB'], (['B', 43]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function component_with_defaultProps_and_spread() 
+	public function component_with_defaultProps_and_spread()
 	{
 		var o = {
 			a:'foo',
@@ -161,19 +162,19 @@ class ReactMacroTest
 		}
 		var e = jsx('<CompDefaults {...o}/>');
 		Assert.areEqual(CompDefaults, e.type);
-		assertHasProps(e.props, ['defA', 'defB', 'a', 'b'], ['A', 42, 'foo', 12]);
+		assertHasProps(e.props, ['defA', 'defB', 'a', 'b'], (['A', 42, 'foo', 12]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function component_with_defaultProps_and_prop_override() 
+	public function component_with_defaultProps_and_prop_override()
 	{
 		var e = jsx('<CompDefaults defA="foo"/>');
 		Assert.areEqual(CompDefaults, e.type);
-		assertHasProps(e.props, ['defA', 'defB'], ['foo', 42]);
+		assertHasProps(e.props, ['defA', 'defB'], (['foo', 42]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function component_with_defaultProps_and_spread_override() 
+	public function component_with_defaultProps_and_spread_override()
 	{
 		var o = {
 			defA:'foo',
@@ -181,11 +182,11 @@ class ReactMacroTest
 		}
 		var e = jsx('<CompDefaults {...o}/>');
 		Assert.areEqual(CompDefaults, e.type);
-		assertHasProps(e.props, ['defA', 'defB', 'b'], ['foo', 42, 12]);
+		assertHasProps(e.props, ['defA', 'defB', 'b'], (['foo', 42, 12]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function component_with_defaultProps_and_spread_and_prop_override() 
+	public function component_with_defaultProps_and_spread_and_prop_override()
 	{
 		var o = {
 			defA:'foo',
@@ -193,11 +194,11 @@ class ReactMacroTest
 		}
 		var e = jsx('<CompDefaults {...o} defA="bar" />');
 		Assert.areEqual(CompDefaults, e.type);
-		assertHasProps(e.props, ['defA', 'defB', 'b'], ['bar', 42, 12]);
+		assertHasProps(e.props, ['defA', 'defB', 'b'], (['bar', 42, 12]:Array<Dynamic>));
 	}
-	
+
 	@Test
-	public function DOM_with_ref_function_should_be_inlined() 
+	public function DOM_with_ref_function_should_be_inlined()
 	{
 		function setRef() {};
 		var e = jsx('<div ref=$setRef />');
@@ -205,24 +206,24 @@ class ReactMacroTest
 		Assert.areEqual(setRef, e.ref);
 		assertHasProps(e.props, []);
 	}
-	
+
 	@Test
-	public function DOM_with_ref_const_string_should_be_DEOPT() 
+	public function DOM_with_ref_const_string_should_be_DEOPT()
 	{
 		var e = jsx('<div ref="myref" />');
 		Assert.areEqual('NATIVE', e.type);
 	}
-	
+
 	@Test
-	public function DOM_with_ref_string_should_be_DEOPT() 
+	public function DOM_with_ref_string_should_be_DEOPT()
 	{
 		var setRef = 'myRef';
 		var e = jsx('<div ref=$setRef />');
 		Assert.areEqual('NATIVE', e.type);
 	}
-	
+
 	@Test
-	public function DOM_with_ref_unknown_should_be_DEOPT() 
+	public function DOM_with_ref_unknown_should_be_DEOPT()
 	{
 		var setRef:Dynamic = function() {};
 		var e = jsx('<div ref=$setRef />');
@@ -230,7 +231,7 @@ class ReactMacroTest
 	}
 
 	@Test
-	public function DOM_with_single_child_text_should_NOT_be_array() 
+	public function DOM_with_single_child_text_should_NOT_be_array()
 	{
 		var e = jsx('<div>hello</div>');
 		Assert.areEqual('div', e.type);
@@ -240,7 +241,7 @@ class ReactMacroTest
 	}
 
 	@Test
-	public function DOM_with_single_child_node_should_NOT_be_array() 
+	public function DOM_with_single_child_node_should_NOT_be_array()
 	{
 		var e = jsx('<div><span/></div>');
 		Assert.areEqual('div', e.type);
@@ -251,16 +252,16 @@ class ReactMacroTest
 	}
 
 	@Test
-	public function DOM_with_single_child_binding_should_NOT_be_array() 
+	public function DOM_with_single_child_binding_should_NOT_be_array()
 	{
-		var o = {};
+		var o = { name:'o' };
 		var e = jsx('<div>${o}</div>');
 		Assert.areEqual('div', e.type);
-		assertHasProps(e.props, ['children'], [o]);
+		Assert.areEqual(e.props.children, o);
 	}
 
 	@Test
-	public function DOM_with_children_should_be_array() 
+	public function DOM_with_children_should_be_array()
 	{
 		var e = jsx('<div>hello <span/></div>');
 		Assert.areEqual('div', e.type);
@@ -270,23 +271,10 @@ class ReactMacroTest
 		Assert.areEqual('hello ', children[0]);
 		Assert.areEqual('span', children[1].type);
 	}
-	
+
 	/* TOOLS */
-	
-	function assertHasProps(o:Dynamic, names:Array<String>, ?values:Array<Dynamic>) 
-	{
-		var props = Reflect.fields(o);
-		Assert.areEqual(names.length, props.length);
-		for (i in 0...names.length)
-		{
-			var name = names[i];
-			Assert.areNotEqual( -1, props.indexOf(name));
-			if (values != null && values[i] != null)
-				Assert.areEqual(values[i], Reflect.field(o, name));
-		}
-	}
-	
-	function RenderFunction() 
+
+	function RenderFunction()
 	{
 		return jsx('<div/>');
 	}

--- a/test/src/TestMain.hx
+++ b/test/src/TestMain.hx
@@ -30,15 +30,15 @@ class TestMain
 			var httpClient = new HTTPClient(new SummaryReportClient());
 		#end
 
-		var runner:TestRunner = new TestRunner(client); 
+		var runner:TestRunner = new TestRunner(client);
 		runner.addResultClient(httpClient);
 		//runner.addResultClient(new HTTPClient(new JUnitReportClient()));
-		
+
 		runner.completionHandler = completionHandler;
-		
-		#if js
+
+		#if (js && !nodejs)
 		var seconds = 0; // edit here to add some startup delay
-		function delayStartup() 
+		function delayStartup()
 		{
 			if (seconds > 0) {
 				seconds--;

--- a/test/src/TestSuite.hx
+++ b/test/src/TestSuite.hx
@@ -8,10 +8,8 @@ import ReactMacroTest;
  * Auto generated Test Suite for MassiveUnit.
  * Refer to munit command line tool for more information (haxelib run munit)
  */
-
 class TestSuite extends massive.munit.TestSuite
-{		
-
+{
 	public function new()
 	{
 		super();

--- a/test/src/react/ReactComponent.hx
+++ b/test/src/react/ReactComponent.hx
@@ -4,7 +4,7 @@ typedef ReactComponentProps = {
 	/**
 		Children have to be manipulated using React.Children.*
 	**/
-	@:optional var children:Dynamic; 
+	@:optional var children:Dynamic;
 }
 
 /**
@@ -18,7 +18,7 @@ typedef ReactComponentOfStateAndRefs<TState, TRefs> = ReactComponentOf<Dynamic, 
 typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState, Dynamic>;
 typedef ReactComponentOfPropsAndRefs<TProps, TRefs> = ReactComponentOf<TProps, Dynamic, TRefs>;
 
-@:autoBuild(react.ReactMacro.buildComponent())
+@:autoBuild(react.ReactComponentMacro.build())
 class ReactComponentOf<TProps, TState, TRefs>
 {
 	static var defaultProps:Dynamic;

--- a/test/test.hxml
+++ b/test/test.hxml
@@ -3,5 +3,6 @@
 -lib hamcrest
 -cp src/lib
 
+-lib hxnodejs
 -cp test/src
 -js test/build/js_test.js


### PR DESCRIPTION
- Fixed unit tests regression
- Improved unit tests error reporting by making `assertHasProps` a macro
- Now using nodejs for execution (atm needs MassiveUnit `fix/js-test` branch with nodejs fixes)