### PR TITLE
Added @:wrap support

### DIFF
--- a/src/lib/react/ReactComponentMacro.hx
+++ b/src/lib/react/ReactComponentMacro.hx
@@ -11,6 +11,7 @@ class ReactComponentMacro {
 	static var builders:Array<Builder> = [
 		react.ReactMacro.buildComponent,
 		react.ReactTypeMacro.alterComponentSignatures,
+		react.wrap.ReactWrapperMacro.buildComponent,
 
 		#if (debug && react_render_warning)
 		react.ReactDebugMacro.buildComponent,

--- a/src/lib/react/wrap/ReactWrapperMacro.hx
+++ b/src/lib/react/wrap/ReactWrapperMacro.hx
@@ -1,0 +1,59 @@
+package react.wrap;
+
+import haxe.macro.ComplexTypeTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.Type;
+import haxe.macro.TypeTools;
+import react.jsx.JsxStaticMacro;
+
+class ReactWrapperMacro
+{
+	static public inline var WRAP_META = ':wrap';
+	static inline var WRAPPED_META = ':wrapped_by_macro';
+
+	static public function buildComponent(inClass:ClassType, fields:Array<Field>):Array<Field>
+	{
+		if (inClass.meta.has(WRAPPED_META)) return fields;
+
+		if (inClass.meta.has(WRAP_META))
+		{
+			if (inClass.meta.has(JsxStaticMacro.META_NAME))
+				Context.fatalError(
+					'Cannot use @${WRAP_META} and @${JsxStaticMacro.META_NAME} on the same component',
+					inClass.pos
+				);
+
+			var prevPos = null;
+			var wrapperExpr = null;
+			var wrappersMeta = inClass.meta.extract(WRAP_META);
+			wrappersMeta.reverse();
+			for (m in wrappersMeta)
+			{
+				if (m.params.length == 0)
+					Context.fatalError('Invalid number of parameters for @${WRAP_META}; expected 1 parameter.', m.pos);
+
+				var e = m.params[0];
+				wrapperExpr = wrapperExpr == null ? macro ${e}($i{inClass.name}) : macro ${e}(${wrapperExpr});
+				prevPos = m.pos;
+			}
+
+			var fieldName = '_renderWrapper';
+			fields.push({
+				access: [APublic, AStatic],
+				name: fieldName,
+				kind: FVar(null, wrapperExpr),
+				doc: null,
+				meta: null,
+				pos: inClass.pos
+			});
+
+			inClass.meta.add(JsxStaticMacro.META_NAME, [macro $v{fieldName}], inClass.pos);
+			inClass.meta.add(WRAPPED_META, [], inClass.pos);
+		}
+
+		return fields;
+	}
+}
+


### PR DESCRIPTION
Use the power of `@:jsxStatic` to wrap a component with multiple wrappers/HOCs: redux's `connect`, i18n with intl, react-router's `withRouter`, etc. with a simple meta.

To wrap a component with a single wrapper:

```haxe
@:wrap(ReactRouter.withRouter)
class MyComponentWithRouter extends ReactComponentOfProps<MyProps>
{
	// ...
}

// And use it with
jsx('<$MyComponentWithRouter />')
```

You can also combine wrappers with multiple metas, `@:wrap` instructions' order will be respected (the first one will be the entry point, and the last one will provide the final props to the component):

```haxe
@:wrap(ReactRouter.withRouter)
@:wrap(ReactIntl.injectIntl)
@:wrap(ReactRedux.connect(MyComponentWithWrappers.mapStateToProps))
class MyComponentWithWrappers extends ReactComponentOfProps<MyProps>
{
	// ...
}

// And use it with
jsx('<$MyComponentWithWrappers />')
```

Will generate the equivalent of `MyComponentWithWrappers = ReactRouter.withRouter(ReactIntl.injectIntl(MyComponent))`