### PR TITLE
Fix @:wrap with -debug and new jsx

### DIFF
--- a/src/lib/react/wrap/ReactWrapperMacro.hx
+++ b/src/lib/react/wrap/ReactWrapperMacro.hx
@@ -43,7 +43,7 @@ class ReactWrapperMacro
 			fields.push({
 				access: [APublic, AStatic],
 				name: fieldName,
-				kind: FVar(null, wrapperExpr),
+				kind: FVar(macro :react.React.CreateElementType, wrapperExpr),
 				doc: null,
 				meta: null,
 				pos: inClass.pos


### PR DESCRIPTION
`@:wrap` works just fine on my projects, with or without `-debug` and `@:connect` from redux.

However, it breaks with @back2dos's jsx implementation + `-debug` which is more demanding regarding types, so I had to add this to make it work.