### PR TITLE
Improve breakpoints on JSX call sites

### DIFF
--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -137,7 +137,7 @@ class ReactMacro
 					var props = makeProps(spread, attrs, pos);
 
 					var args = [type, props].concat(children);
-					return macro react.React.createElement($a{args});
+					return macro @:pos(pos) react.React.createElement($a{args});
 				}
 		}
 	}


### PR DESCRIPTION
Normally adding a breakpoint on a JSX line sends you in `ReactMacro`, which is confusing.