### PR TITLE
`@:jsxStatic`: add field for identifying jsxStatic components

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,0 +1,2 @@
+--macro addGlobalMetadata('', '@:build(react.jsx.JsxStaticMacro.build())')
+

--- a/src/lib/react/jsx/JsxStaticMacro.hx
+++ b/src/lib/react/jsx/JsxStaticMacro.hx
@@ -29,13 +29,13 @@ class JsxStaticMacro
 
 	static public function build():Array<Field>
 	{
-		var fields = Context.getBuildFields();
 		var cls = Context.getLocalClass();
-		if (cls == null) return fields;
+		if (cls == null) return null;
 		var inClass = cls.get();
 
 		if (inClass.meta.has(META_NAME))
 		{
+			var fields = Context.getBuildFields();
 			for (f in fields) if (f.name == FIELD_NAME) return fields;
 
 			var proxyName = extractMetaString(inClass.meta, META_NAME);
@@ -47,9 +47,11 @@ class JsxStaticMacro
 				meta: null,
 				pos: inClass.pos
 			});
+
+			return fields;
 		}
 
-		return fields;
+		return null;
 	}
 
 	static public function injectDisplayNames(type:Expr)

--- a/src/lib/react/jsx/JsxStaticMacro.hx
+++ b/src/lib/react/jsx/JsxStaticMacro.hx
@@ -22,9 +22,35 @@ private enum MetaValueType {
 class JsxStaticMacro
 {
 	static public var META_NAME = ':jsxStatic';
+	static public var FIELD_NAME = '__jsxStatic';
 
 	static var hasBeenHooked = false;
 	static var decls:Array<JsxStaticDecl> = [];
+
+	static public function build():Array<Field>
+	{
+		var fields = Context.getBuildFields();
+		var cls = Context.getLocalClass();
+		if (cls == null) return fields;
+		var inClass = cls.get();
+
+		if (inClass.meta.has(META_NAME))
+		{
+			for (f in fields) if (f.name == FIELD_NAME) return fields;
+
+			var proxyName = extractMetaString(inClass.meta, META_NAME);
+			fields.push({
+				access: [APublic, AStatic],
+				name: FIELD_NAME,
+				kind: FVar(macro :react.React.CreateElementType, macro $i{proxyName}),
+				doc: null,
+				meta: null,
+				pos: inClass.pos
+			});
+		}
+
+		return fields;
+	}
 
 	static public function injectDisplayNames(type:Expr)
 	{


### PR DESCRIPTION
Allows identification of a component as a `@:jsxStatic` component outside the `jsx(' ... ')` macro, by adding a `__jsxStatic:CreateElementType` static field to classes with `@:jsxStatic` meta.

Example usage:
```haxe
private abstract BundledComponent(Class<ReactComponent>) {
	// ...

	@:to
	public function toCreateElementType():CreateElementType {
		if (untyped this.__jsxStatic != null)
			return untyped this.__jsxStatic;

		return this;
	}
}
```