### PR TITLE
CreateElementType as abstract & ReactFragment

### DIFF
--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -1,6 +1,5 @@
 package react;
 
-#if !macro
 import react.ReactComponent.ReactElement;
 import react.ReactComponent.ReactFragment;
 
@@ -69,81 +68,6 @@ extern interface ReactChildren
 	function toArray(children:Dynamic):Array<Dynamic>;
 }
 
-private typedef CET = haxe.extern.EitherType<haxe.extern.EitherType<String, haxe.Constraints.Function>, Class<ReactComponent>>;
-#end
+@:deprecated
+typedef CreateElementType = ReactNode;
 
-#if macro
-import haxe.macro.Expr;
-import haxe.macro.Context;
-
-abstract CreateElementType(Dynamic)
-#else
-abstract CreateElementType(CET) to CET
-#end
-{
-	#if !macro
-	@:from
-	static public function fromString(s:String):CreateElementType
-	{
-		return cast s;
-	}
-
-	@:from
-	static public function fromFunction(f:Void->ReactFragment):CreateElementType
-	{
-		return cast f;
-	}
-
-	@:from
-	static public function fromFunctionWithProps<TProps>(f:TProps->ReactFragment):CreateElementType
-	{
-		return cast f;
-	}
-
-	@:from
-	static public function fromComp(cls:Class<ReactComponent>):CreateElementType
-	{
-		if (untyped cls.__jsxStatic != null)
-			return untyped cls.__jsxStatic;
-
-		return cast cls;
-	}
-	#end
-
-	@:from
-	static public macro function fromExpr(expr:Expr)
-	{
-		switch (Context.typeof(expr)) {
-			case TType(_.get() => def, _):
-				try {
-					var module = ReactMacro.resolveDefModule(def);
-
-					switch (Context.getType(module)) {
-						case TInst(_.get() => clsType, _):
-							if (!clsType.meta.has(react.jsx.JsxStaticMacro.META_NAME))
-								Context.error(
-									'Incompatible class for CreateElementType: expected a ReactComponent or a @:jsxStatic component',
-									expr.pos
-								);
-							else
-								return macro $expr.__jsxStatic;
-
-						default: throw '';
-					}
-				} catch (e:Dynamic) {
-					Context.error(
-						'Incompatible expression for CreateElementType',
-						expr.pos
-					);
-				}
-
-			default:
-				Context.error(
-					'Incompatible expression for CreateElementType',
-					expr.pos
-				);
-		}
-
-		return null;
-	}
-}

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -1,6 +1,7 @@
 package react;
 
 import react.ReactComponent.ReactElement;
+import react.ReactComponent.ReactFragment;
 
 /**
 	https://facebook.github.io/react/docs/react-api.html
@@ -16,7 +17,7 @@ extern class React
 	/**
 		https://facebook.github.io/react/docs/react-api.html#createelement
 	**/
-	public static function createElement(type:CreateElementType, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactElement;
+	public static function createElement(type:CreateElementType, ?attrs:Dynamic, children:haxe.extern.Rest<Dynamic>):ReactFragment;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#cloneelement
@@ -44,12 +45,12 @@ extern interface ReactChildren
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children.map
 	**/
-	function map(children:Dynamic, fn:ReactElement->ReactElement):Dynamic;
+	function map(children:Dynamic, fn:ReactFragment->ReactFragment):Dynamic;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children.foreach
 	**/
-	function foreach(children:Dynamic, fn:ReactElement->Void):Void;
+	function foreach(children:Dynamic, fn:ReactFragment->Void):Void;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children.count
@@ -67,4 +68,34 @@ extern interface ReactChildren
 	function toArray(children:Dynamic):Array<Dynamic>;
 }
 
-typedef CreateElementType = haxe.extern.EitherType<haxe.extern.EitherType<String, haxe.Constraints.Function>, Class<ReactComponent>>;
+private typedef CET = haxe.extern.EitherType<haxe.extern.EitherType<String, haxe.Constraints.Function>, Class<ReactComponent>>;
+
+abstract CreateElementType(CET) to CET
+{
+	@:from
+	static public function fromString(s:String):CreateElementType
+	{
+		return cast s;
+	}
+
+	@:from
+	static public function fromFunction(f:Void->ReactFragment):CreateElementType
+	{
+		return cast f;
+	}
+
+	@:from
+	static public function fromFunctionWithProps<TProps>(f:TProps->ReactFragment):CreateElementType
+	{
+		return cast f;
+	}
+
+	@:from
+	static public function fromComp(cls:Class<ReactComponent>):CreateElementType
+	{
+		if (untyped cls.__jsxStatic != null)
+			return untyped cls.__jsxStatic;
+
+		return cast cls;
+	}
+}

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -1,5 +1,6 @@
 package react;
 import js.Error;
+import haxe.extern.EitherType;
 
 typedef ReactComponentProps = {
 	/**
@@ -53,7 +54,7 @@ extern class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/react-component.html#render
 	**/
-	function render():ReactElement;
+	function render():ReactFragment;
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentwillmount
@@ -109,3 +110,11 @@ typedef ReactElement = {
 	?key:Dynamic,
 	?ref:Dynamic
 }
+
+typedef ReactFragment = EitherType<
+	ReactElement,
+	EitherType<
+		Array<ReactFragment>,
+		EitherType<String, Float>
+	>
+>;

--- a/src/lib/react/ReactDOM.hx
+++ b/src/lib/react/ReactDOM.hx
@@ -15,12 +15,12 @@ extern class ReactDOM
 	/**
 		https://facebook.github.io/react/docs/react-dom.html#render
 	**/
-	public static function render(element:ReactElement, container:Element, ?callback:Void -> Void):ReactElement;
+	public static function render(element:ReactFragment, container:Element, ?callback:Void -> Void):ReactFragment;
 
 	/**
 		https://facebook.github.io/react/docs/react-dom.html#hydrate
 	**/
-	public static function hydrate(element:ReactElement, container:Element, ?callback:Void -> Void):ReactElement;
+	public static function hydrate(element:ReactFragment, container:Element, ?callback:Void -> Void):ReactFragment;
 
 	/**
 		https://facebook.github.io/react/docs/react-dom.html#unmountcomponentatnode
@@ -35,5 +35,5 @@ extern class ReactDOM
 	/**
 		https://reactjs.org/docs/react-dom.html#createportal
 	**/
-	public static function createPortal(child:ReactElement, container:Element):ReactElement;
+	public static function createPortal(child:ReactFragment, container:Element):ReactFragment;
 }

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -84,8 +84,14 @@ class ReactMacro
 				var type = isHtml ? macro $v{path[0]} : macro $p{path};
 				type.pos = pos;
 
-				// handle @:jsxStatic
-				if (!isHtml) JsxStaticMacro.handleJsxStaticProxy(type);
+				if (!isHtml) {
+					// handle @:jsxStatic
+					JsxStaticMacro.handleJsxStaticProxy(type);
+
+					// Check type of node to avoid runtime error
+					if (!Context.unify(Context.typeof(type), Context.getType('react.React.CreateElementType')))
+						Context.error('JSX error: invalid node "${ExprTools.toString(type)}"', pos);
+				}
 
 				// parse attributes
 				var attrs = [];

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -89,8 +89,12 @@ class ReactMacro
 					JsxStaticMacro.handleJsxStaticProxy(type);
 
 					// Check type of node to avoid runtime error
-					if (!Context.unify(Context.typeof(type), Context.getType('react.React.CreateElementType')))
+					try {
+						if (!Context.unify(Context.typeof(type), Context.getType('react.React.CreateElementType')))
+							Context.error('JSX error: invalid node "${ExprTools.toString(type)}"', pos);
+					} catch (e:Dynamic) {
 						Context.error('JSX error: invalid node "${ExprTools.toString(type)}"', pos);
+					}
 				}
 
 				// parse attributes
@@ -383,6 +387,22 @@ class ReactMacro
 			case Type.TType(_.get() => t, _): t.name;
 			default: null;
 		}
+	}
+
+	static var defReg = ~/(?|Class|Enum)<(?>[a-z_]+[a-zA-Z0-9_]*\.)*([A-Z_]+[a-zA-Z0-9_]*)>/;
+	static var moduleReg = ~/(?>[a-z_]+[a-zA-Z0-9_]*\.)*([A-Z_]+[a-zA-Z0-9_]*)/;
+
+	public static function resolveDefModule(def:haxe.macro.DefType):String
+	{
+		var module = def.module;
+
+		var defName = defReg.match(def.name) ? defReg.matched(1) : null;
+		var moduleName = moduleReg.match(module) ? moduleReg.matched(1) : null;
+
+		if (defName != null && moduleName != null && defName != moduleName)
+			module = '$module.$defName';
+
+		return module;
 	}
 	#end
 }

--- a/src/lib/react/ReactNode.hx
+++ b/src/lib/react/ReactNode.hx
@@ -1,0 +1,83 @@
+package react;
+
+import haxe.Constraints.Function;
+import haxe.extern.EitherType;
+import react.ReactComponent.ReactElement;
+import react.ReactComponent.ReactFragment;
+
+#if macro
+import haxe.macro.Expr;
+import haxe.macro.Context;
+
+abstract ReactNode(Dynamic)
+#else
+private typedef Node = EitherType<EitherType<String, Function>, Class<ReactComponent>>;
+abstract ReactNode(Node) to Node
+#end
+{
+	#if !macro
+	@:from
+	static public function fromString(s:String):ReactNode
+	{
+		return cast s;
+	}
+
+	@:from
+	static public function fromFunction(f:Void->ReactFragment):ReactNode
+	{
+		return cast f;
+	}
+
+	@:from
+	static public function fromFunctionWithProps<TProps>(f:TProps->ReactFragment):ReactNode
+	{
+		return cast f;
+	}
+
+	@:from
+	static public function fromComp(cls:Class<ReactComponent>):ReactNode
+	{
+		if (untyped cls.__jsxStatic != null)
+			return untyped cls.__jsxStatic;
+
+		return cast cls;
+	}
+	#end
+
+	@:from
+	static public macro function fromExpr(expr:Expr)
+	{
+		switch (Context.typeof(expr)) {
+			case TType(_.get() => def, _):
+				try {
+					var module = ReactMacro.resolveDefModule(def);
+
+					switch (Context.getType(module)) {
+						case TInst(_.get() => clsType, _):
+							if (!clsType.meta.has(react.jsx.JsxStaticMacro.META_NAME))
+								Context.error(
+									'Incompatible class for ReactNode: expected a ReactComponent or a @:jsxStatic component',
+									expr.pos
+								);
+							else
+								return macro $expr.__jsxStatic;
+
+						default: throw '';
+					}
+				} catch (e:Dynamic) {
+					Context.error(
+						'Incompatible expression for ReactNode',
+						expr.pos
+					);
+				}
+
+			default:
+				Context.error(
+					'Incompatible expression for ReactNode',
+					expr.pos
+				);
+		}
+
+		return null;
+	}
+}

--- a/test/src/ReactMacroTest.hx
+++ b/test/src/ReactMacroTest.hx
@@ -75,21 +75,21 @@ class ReactMacroTest
 	@Test
 	public function extern_component_qualified_module_should_DEOPT()
 	{
-		var e = jsx('<support.sub.CompExternModule />');
+		var e:ReactElement = cast jsx('<support.sub.CompExternModule />');
 		Assert.areEqual('NATIVE', e.type);
 	}
 
 	@Test
 	public function extern_component_module_should_DEOPT()
 	{
-		var e = jsx('<CompExternModule />');
+		var e:ReactElement = cast jsx('<CompExternModule />');
 		Assert.areEqual('NATIVE', e.type);
 	}
 
 	@Test
 	public function extern_component_should_DEOPT()
 	{
-		var e = jsx('<CompExtern />');
+		var e:ReactElement = cast jsx('<CompExtern />');
 		Assert.areEqual('NATIVE', e.type);
 	}
 
@@ -210,7 +210,7 @@ class ReactMacroTest
 	@Test
 	public function DOM_with_ref_const_string_should_be_DEOPT()
 	{
-		var e = jsx('<div ref="myref" />');
+		var e:ReactElement = cast jsx('<div ref="myref" />');
 		Assert.areEqual('NATIVE', e.type);
 	}
 
@@ -218,7 +218,7 @@ class ReactMacroTest
 	public function DOM_with_ref_string_should_be_DEOPT()
 	{
 		var setRef = 'myRef';
-		var e = jsx('<div ref=$setRef />');
+		var e:ReactElement = cast jsx('<div ref=$setRef />');
 		Assert.areEqual('NATIVE', e.type);
 	}
 
@@ -226,7 +226,7 @@ class ReactMacroTest
 	public function DOM_with_ref_unknown_should_be_DEOPT()
 	{
 		var setRef:Dynamic = function() {};
-		var e = jsx('<div ref=$setRef />');
+		var e:ReactElement = cast jsx('<div ref=$setRef />');
 		Assert.areEqual('NATIVE', e.type);
 	}
 

--- a/test/src/TestSuite.hx
+++ b/test/src/TestSuite.hx
@@ -1,7 +1,7 @@
 import massive.munit.TestSuite;
 
-import JsxParserTest;
 import JsxSanitizeTest;
+import JsxParserTest;
 import ReactMacroTest;
 
 /**
@@ -14,8 +14,8 @@ class TestSuite extends massive.munit.TestSuite
 	{
 		super();
 
-		add(JsxParserTest);
 		add(JsxSanitizeTest);
+		add(JsxParserTest);
 		add(ReactMacroTest);
 	}
 }

--- a/test/src/react/React.hx
+++ b/test/src/react/React.hx
@@ -1,6 +1,7 @@
 package react;
 
 import react.ReactComponent.ReactElement;
+import react.ReactComponent.ReactFragment;
 
 /**
 	STUB
@@ -15,7 +16,7 @@ class React
 	/**
 		https://facebook.github.io/react/docs/react-api.html#createelement
 	**/
-	public static function createElement(type:CreateElementType, ?attrs:Dynamic, ?children:Dynamic):ReactElement
+	public static function createElement(type:CreateElementType, ?attrs:Dynamic, ?children:Dynamic):ReactFragment
 	{
 		return untyped { type:'NATIVE' };
 	}
@@ -50,12 +51,12 @@ extern interface ReactChildren
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children.map
 	**/
-	function map(children:Dynamic, fn:ReactElement->ReactElement):Dynamic;
+	function map(children:Dynamic, fn:ReactFragment->ReactFragment):Dynamic;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children.foreach
 	**/
-	function foreach(children:Dynamic, fn:ReactElement->Void):Void;
+	function foreach(children:Dynamic, fn:ReactFragment->Void):Void;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children.count
@@ -73,4 +74,34 @@ extern interface ReactChildren
 	function toArray(children:Dynamic):Array<Dynamic>;
 }
 
-typedef CreateElementType = haxe.extern.EitherType<haxe.extern.EitherType<String, haxe.Constraints.Function>, Class<ReactComponent>>;
+private typedef CET = haxe.extern.EitherType<haxe.extern.EitherType<String, haxe.Constraints.Function>, Class<ReactComponent>>;
+
+abstract CreateElementType(CET) to CET
+{
+	@:from
+	static public function fromString(s:String):CreateElementType
+	{
+		return cast s;
+	}
+
+	@:from
+	static public function fromFunction(f:Void->ReactFragment):CreateElementType
+	{
+		return cast f;
+	}
+
+	@:from
+	static public function fromFunctionWithProps<TProps>(f:TProps->ReactFragment):CreateElementType
+	{
+		return cast f;
+	}
+
+	@:from
+	static public function fromComp(cls:Class<ReactComponent>):CreateElementType
+	{
+		if (untyped cls.__jsxStatic != null)
+			return untyped cls.__jsxStatic;
+
+		return cast cls;
+	}
+}

--- a/test/src/react/ReactComponent.hx
+++ b/test/src/react/ReactComponent.hx
@@ -48,7 +48,7 @@ class ReactComponentOf<TProps, TState, TRefs>
 	/**
 		https://facebook.github.io/react/docs/react-component.html#render
 	**/
-	function render():ReactElement { return null; }
+	function render():ReactFragment { return null; }
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentwillmount
@@ -97,3 +97,11 @@ typedef ReactElement = {
 	?key:Dynamic,
 	?ref:Dynamic
 }
+
+typedef ReactFragment = EitherType<
+	ReactElement,
+	EitherType<
+		Array<ReactFragment>,
+		EitherType<String, Float>
+	>
+>;

--- a/test/src/react/ReactComponent.hx
+++ b/test/src/react/ReactComponent.hx
@@ -1,4 +1,5 @@
 package react;
+import haxe.extern.EitherType;
 
 typedef ReactComponentProps = {
 	/**


### PR DESCRIPTION
Replaced `CreateElementType` by an abstract, allowing:
 * Stricter type checking for `haxe.Constraints.Function`
 * Support for `@:jsxStatic` (only handled inside JSX macro at the moment)
 * Better typing support in macros

Added a compilation error inside JSX macro when a node is not compatible, avoiding a strange runtime error. This compilation error has a correct position, pointing to the node inside the jsx string. I have a version for hxx, too.

Added `ReactFragment`, allowing more types as `render()` return type (and some other API functions too), to match reactjs:
 * `ReactElement`
 * `String`
 * `Float`
 * An array (possibly a mixed array) of `ReactFragment`


This should be retro-compatible, since the new types either extend the previous types or disallow types that should fail at runtime.