### PR TITLE
New refs API (React 16.3)

### DIFF
--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -1,5 +1,6 @@
 package react;
 
+import js.html.Element;
 import react.ReactComponent.ReactElement;
 
 /**
@@ -27,6 +28,25 @@ extern class React
 		https://facebook.github.io/react/docs/react-api.html#isvalidelement
 	**/
 	public static function isValidElement(object:Dynamic):Bool;
+
+	/**
+		https://reactjs.org/docs/react-api.html#reactcreateref
+
+		Note: this API has been introduced in React 16.3
+		If you are using an earlier release of React, use callback refs instead
+		https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
+	**/
+	public static function createRef<TRef:Element>():ReactRef<TRef>;
+
+	/**
+		https://reactjs.org/docs/react-api.html#reactforwardref
+		See also https://reactjs.org/docs/forwarding-refs.html
+
+		Note: this API has been introduced in React 16.3
+		If you are using an earlier release of React, use callback refs instead
+		https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
+	**/
+	public static function forwardRef<TProps, TRef:Element>(render:TProps->ReactRef<TRef>->ReactElement):CreateElementType;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -1,6 +1,5 @@
 package react;
 
-import js.html.Element;
 import react.ReactComponent.ReactElement;
 
 /**
@@ -36,7 +35,7 @@ extern class React
 		If you are using an earlier release of React, use callback refs instead
 		https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
 	**/
-	public static function createRef<TRef:Element>():ReactRef<TRef>;
+	public static function createRef<TRef>():ReactRef<TRef>;
 
 	/**
 		https://reactjs.org/docs/react-api.html#reactforwardref
@@ -46,7 +45,7 @@ extern class React
 		If you are using an earlier release of React, use callback refs instead
 		https://reactjs.org/docs/refs-and-the-dom.html#callback-refs
 	**/
-	public static function forwardRef<TProps, TRef:Element>(render:TProps->ReactRef<TRef>->ReactElement):CreateElementType;
+	public static function forwardRef<TProps, TRef>(render:TProps->ReactRef<TRef>->ReactElement):CreateElementType;
 
 	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children

--- a/src/lib/react/ReactRef.hx
+++ b/src/lib/react/ReactRef.hx
@@ -1,0 +1,14 @@
+package react;
+
+import haxe.Constraints.Function;
+import js.html.Element;
+
+@:callable
+abstract ReactRef<T:Element>(Function) {
+	public var current(get, never):T;
+
+	public function get_current():T {
+		return untyped this.current;
+	}
+}
+

--- a/src/lib/react/ReactRef.hx
+++ b/src/lib/react/ReactRef.hx
@@ -1,10 +1,9 @@
 package react;
 
 import haxe.Constraints.Function;
-import js.html.Element;
 
 @:callable
-abstract ReactRef<T:Element>(Function) {
+abstract ReactRef<T>(Function) {
 	public var current(get, never):T;
 
 	public function get_current():T {


### PR DESCRIPTION
Added [`React.createRef()`](https://reactjs.org/docs/react-api.html#reactcreateref) and [`React.forwardRef()`](https://reactjs.org/docs/react-api.html#reactforwardref) from the new refs API introduced in React 16.3

Example usage:
```haxe
import js.html.InputElement;
import react.React;
import react.ReactRef;
import react.ReactComponent;
import react.ReactMacro.jsx;

class TestComponent extends ReactComponentOfState<{message: String}> {
	var inputRef:ReactRef<InputElement> = React.createRef();

	public function new(props) {
		super(props);
		state = {message: ""};
	}

	override public function render() {
		return jsx('
			<>
				<span>${state.message}</span>
				<input ref=${inputRef} type="text" />
				<button onClick=${updateMessage}>Update</button>
			</>
		');
	}

	function updateMessage() {
		setState({message: inputRef.current.value});
	}
}
```

We can also use `var inputRef = React.createRef();` but I personally prefer to type my refs to the underlying element.