### PR TITLE
Fix react production mode with haxe 4

### DIFF
--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -163,7 +163,11 @@ class ReactMacro
 		if (ref == null) ref = macro null;
 
 		var fields = [
+			#if (haxe_ver < 4)
 			{field: "@$__hx__$$typeof", expr: macro untyped __js__("$$tre")},
+			#else
+			{field: "$$typeof", expr: macro untyped __js__("$$tre")},
+			#end
 			{field: 'type', expr: type},
 			{field: 'props', expr: props}
 		];


### PR DESCRIPTION
The `@$__hx__` trick is no longer needed in haxe 4 (and doesn't work anymore), see https://github.com/HaxeFoundation/haxe/issues/2642

This only happens when using production react, and throws
```
Objects are not valid as a React child (found: object with keys {@$__hx__$$typeof, type, props, key, ref}).
```