### PR TITLE
Debug: add warning if ReactComponent's render has no override

### DIFF
--- a/src/lib/react/ReactComponentMacro.hx
+++ b/src/lib/react/ReactComponentMacro.hx
@@ -13,6 +13,10 @@ class ReactComponentMacro {
 		react.ReactTypeMacro.alterComponentSignatures,
 		react.wrap.ReactWrapperMacro.buildComponent,
 
+		#if (debug && !react_ignore_empty_render)
+		react.ReactTypeMacro.ensureRenderOverride,
+		#end
+
 		#if (debug && react_render_warning)
 		react.ReactDebugMacro.buildComponent,
 		#end

--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -35,6 +35,20 @@ class ReactTypeMacro
 		return fields;
 	}
 
+	public static function ensureRenderOverride(inClass:ClassType, fields:Array<Field>):Array<Field>
+	{
+		if (!inClass.isExtern)
+			if (!Lambda.exists(fields, function(f) return f.name == 'render'))
+				Context.warning(
+					'Component ${inClass.name}: '
+					+ 'No `render` method found: you may have forgotten to '
+					+ 'override `render` from `ReactComponent`.',
+					inClass.pos
+				);
+
+		return fields;
+	}
+
 	static function hasSetState(fields:Array<Field>) {
 		for (field in fields)
 		{


### PR DESCRIPTION
If we do not override `render()` in a `ReactComponent`, we get a **runtime** warning from React, followed by a runtime error:
```
Warning: MyComponent(...): No `render` method found on the returned component instance: you may have forgotten to define `render`.
Uncaught TypeError: instance.render is not a function
```

This PR adds a **compile-time** check for a `render()` override in all *non-extern* `ReactComponent` classes (well, only those already included in the compilation).

A *warning* will be triggered if no `render()` override is found:
```
src/.../MyComponent.hx:42: lines 42-51 : Warning : Component MyComponent: No `render` method found: you may have forgotten to override `render` from `ReactComponent`.
```

This PR does nothing if:
 * we are compiling without `-debug`
 * we are compiling with `-debug`, but also with `-D react_ignore_empty_render`

### Caveat
Parent classes are not checked for an override of `render()`, so there may be false positives when using `MyComponent extends MyParentComponent` (which itself extends `ReactComponent`).

This is not a recommended practice anyway, but the false positives can then be ignored with `-D react_ignore_empty_render`. It could be properly checked, but I don't think it's worth the effort (and additional compilation time).