### PR TITLE
@:jsxStatic: allow unquoted function names

### DIFF
--- a/src/lib/react/jsx/JsxStaticMacro.hx
+++ b/src/lib/react/jsx/JsxStaticMacro.hx
@@ -149,11 +149,25 @@ class JsxStaticMacro
 	{
 		return switch(extractMeta(meta, name)) {
 			case NoMeta: null;
-			case WithParams(_, params): params.pop().getValue();
+			case WithParams(_, params): extractMetaName(params.pop());
 			case NoParams(meta):
 				Context.fatalError(
 					"Parameter required for @:jsxStatic('name-of-static-function')",
 					meta.pos
+				);
+		};
+	}
+
+	static public function extractMetaName(metaExpr:Expr):String
+	{
+		return switch (metaExpr.expr) {
+			case EConst(CString(str)): str;
+			case EConst(CIdent(ident)): ident;
+
+			default:
+				Context.fatalError(
+					"@:jsxStatic: invalid parameter. Expected static function name.",
+					metaExpr.pos
 				);
 		};
 	}


### PR DESCRIPTION
Current implementation only allows quoted function names in `@:jsxStatic`:

```haxe
@:jsxStatic('render')
class MyComponent {
  static public function render() {
    return "It works!";
  }
}
```

With this PR, you can also use unquoted function names, which might even trigger completion on some editors:
```haxe
@:jsxStatic(render)
class MyComponent {
  static public function render() {
    return "It works too!";
  }
}
```