### PR TITLE
ReactComponentMacro: add optional keys to builders

### DIFF
--- a/src/lib/react/ReactComponentMacro.hx
+++ b/src/lib/react/ReactComponentMacro.hx
@@ -5,25 +5,70 @@ import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 
+import react.wrap.ReactWrapperMacro;
+
 typedef Builder = ClassType -> Array<Field> -> Array<Field>;
+typedef BuilderWithKey = {?key:String, build:Builder};
 
 class ReactComponentMacro {
-	static var builders:Array<Builder> = [
-		react.ReactMacro.buildComponent,
-		react.ReactTypeMacro.alterComponentSignatures,
-		react.wrap.ReactWrapperMacro.buildComponent,
+	static public inline var REACT_COMPONENT_BUILDER = "ReactComponent";
 
-		#if (debug && !react_ignore_empty_render)
-		react.ReactTypeMacro.ensureRenderOverride,
+	static var builders:Array<BuilderWithKey> = [
+		{build: ReactMacro.buildComponent, key: REACT_COMPONENT_BUILDER},
+		{build: ReactTypeMacro.alterComponentSignatures, key: ReactTypeMacro.ALTER_SIGNATURES_BUILDER},
+		{build: ReactWrapperMacro.buildComponent, key: ReactWrapperMacro.WRAP_BUILDER},
+
+		#if !react_ignore_empty_render
+		{build: ReactTypeMacro.ensureRenderOverride, key: ReactTypeMacro.ENSURE_RENDER_OVERRIDE_BUILDER},
 		#end
 
-		#if (debug && react_render_warning)
-		react.ReactDebugMacro.buildComponent,
+		#if (debug && react_runtime_warnings)
+		{build: ReactDebugMacro.buildComponent, key: ReactDebugMacro.REACT_DEBUG_BUILDER}
 		#end
 	];
 
-	static public function appendBuilder(builder:Builder):Void builders.push(builder);
-	static public function prependBuilder(builder:Builder):Void builders.unshift(builder);
+	static public function appendBuilder(builder:Builder, ?key:String):Void {
+		builders.push({build: builder, key: key});
+	}
+
+	static public function prependBuilder(builder:Builder, ?key:String):Void {
+		builders.unshift({build: builder, key: key});
+	}
+
+	static public function hasBuilder(key:String):Bool {
+		if (key == null) return false;
+		return Lambda.exists(builders, function(b) return b.key == key);
+	}
+
+	static public function insertBuilderBefore(before:String, builder:Builder, ?key:String):Void {
+		var index = -1;
+		if (before != null) {
+			for (i in 0...builders.length) {
+				if (builders[i].key == before) {
+					index = i;
+					break;
+				}
+			}
+		}
+
+		if (index == -1) return appendBuilder(builder, key);
+		builders.insert(index, {build: builder, key: key});
+	}
+
+	static public function insertBuilderAfter(after:String, builder:Builder, ?key:String):Void {
+		var index = -1;
+		if (after != null) {
+			for (i in 0...builders.length) {
+				if (builders[i].key == after) {
+					index = i + 1;
+					break;
+				}
+			}
+		}
+
+		if (index == -1) return appendBuilder(builder, key);
+		builders.insert(index, {build: builder, key: key});
+	}
 
 	static public function build():Array<Field>
 	{
@@ -31,7 +76,7 @@ class ReactComponentMacro {
 
 		return Lambda.fold(
 			builders,
-			function(builder, fields) return builder(inClass, fields),
+			function(builder, fields) return builder.build(inClass, fields),
 			Context.getBuildFields()
 		);
 	}

--- a/src/lib/react/ReactDebugMacro.hx
+++ b/src/lib/react/ReactDebugMacro.hx
@@ -8,6 +8,7 @@ import haxe.macro.TypeTools;
 class ReactDebugMacro
 {
 	public static inline var IGNORE_RENDER_WARNING_META = ':ignoreRenderWarning';
+	public static inline var REACT_DEBUG_BUILDER = 'ReactDebug';
 	public static var firstRenderWarning:Bool = true;
 
 	#if macro

--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -8,6 +8,9 @@ import haxe.macro.TypeTools;
 
 class ReactTypeMacro
 {
+	static public inline var ALTER_SIGNATURES_BUILDER = 'AlterSignatures';
+	static public inline var ENSURE_RENDER_OVERRIDE_BUILDER = 'EnsureRenderOverride';
+
 	#if macro
 	public static function alterComponentSignatures(inClass:ClassType, fields:Array<Field>):Array<Field>
 	{

--- a/src/lib/react/wrap/ReactWrapperMacro.hx
+++ b/src/lib/react/wrap/ReactWrapperMacro.hx
@@ -10,6 +10,7 @@ import react.jsx.JsxStaticMacro;
 
 class ReactWrapperMacro
 {
+	static public inline var WRAP_BUILDER = 'Wrap';
 	static public inline var WRAP_META = ':wrap';
 	static inline var WRAPPED_META = ':wrapped_by_macro';
 


### PR DESCRIPTION
I am working on a compatibility lib for people wanting to use this lib instead of `react-next` while still using libs written for `react-next`. I have a working prototype, but this improvement from `react-next` is still missing.

This is an improvement over #97, allowing the use of keys for ReactComponent builders. This is especially useful when builders like `@:connect` (for which I'll update the PR if this gets merged and released) needs to be executed before another specific builder (`@:wrap`).