### PR TITLE
Quickfix for haxe 4 preview 5 warnings

### DIFF
--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -127,7 +127,11 @@ class ReactTypeMacro
 			kind: FFun({
 				args: setStateArgs,
 				ret: macro :Void,
+				#if haxe4
+				expr: null
+				#else
 				expr: macro { super.setState(nextState, callback); }
+				#end
 			}),
 			pos: inClass.pos
 		});


### PR DESCRIPTION
~~Use `-D haxe4preview5` when compiling with haxe 4 preview 5
to get rid of all "Extern non-inline function may not have an
expression" warnings.~~

Proper fix for haxe 4.0.0 rc1 and later, using the `haxe4` flag set by haxe itself.