### PR TITLE
Renamed legacy lifecycle methods

### DIFF
--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -60,9 +60,13 @@ extern class ReactComponentOf<TProps, TState>
 	function render():ReactElement;
 
 	/**
-		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillmount
+		https://facebook.github.io/react/docs/react-component.html#componentwillmount
 	**/
+	#if (react_ver > 16.08)
 	function UNSAFE_componentWillMount():Void;
+	#else
+	function componentWillMount():Void;
+	#end
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentdidmount
@@ -75,9 +79,13 @@ extern class ReactComponentOf<TProps, TState>
 	function componentWillUnmount():Void;
 
 	/**
-		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillreceiveprops
+		https://facebook.github.io/react/docs/react-component.html#componentwillreceiveprops
 	**/
+	#if (react_ver > 16.08)
 	function UNSAFE_componentWillReceiveProps(nextProps:TProps):Void;
+	#else
+	function componentWillReceiveProps(nextProps:TProps):Void;
+	#end
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#shouldcomponentupdate
@@ -85,9 +93,13 @@ extern class ReactComponentOf<TProps, TState>
 	dynamic function shouldComponentUpdate(nextProps:TProps, nextState:TState):Bool;
 
 	/**
-		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillupdate
+		https://facebook.github.io/react/docs/react-component.html#componentwillupdate
 	**/
+	#if (react_ver > 16.08)
 	function UNSAFE_componentWillUpdate(nextProps:TProps, nextState:TState):Void;
+	#else
+	function componentWillUpdate(nextProps:TProps, nextState:TState):Void;
+	#end
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentdidupdate

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -65,6 +65,11 @@ extern class ReactComponentOf<TProps, TState>
 	function componentWillMount():Void;
 
 	/**
+		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillmount
+	**/
+	function UNSAFE_componentWillMount():Void;
+
+	/**
 		https://facebook.github.io/react/docs/react-component.html#componentdidmount
 	**/
 	function componentDidMount():Void;
@@ -80,6 +85,11 @@ extern class ReactComponentOf<TProps, TState>
 	function componentWillReceiveProps(nextProps:TProps):Void;
 
 	/**
+		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillreceiveprops
+	**/
+	function UNSAFE_componentWillReceiveProps(nextProps:TProps):Void;
+
+	/**
 		https://facebook.github.io/react/docs/react-component.html#shouldcomponentupdate
 	**/
 	dynamic function shouldComponentUpdate(nextProps:TProps, nextState:TState):Bool;
@@ -88,6 +98,11 @@ extern class ReactComponentOf<TProps, TState>
 		https://facebook.github.io/react/docs/react-component.html#componentwillupdate
 	**/
 	function componentWillUpdate(nextProps:TProps, nextState:TState):Void;
+
+	/**
+		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillupdate
+	**/
+	function UNSAFE_componentWillUpdate(nextProps:TProps, nextState:TState):Void;
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#componentdidupdate
@@ -111,7 +126,7 @@ extern class ReactComponentOf<TProps, TState>
 	#if react_snapshot_api
 	function getSnapshotBeforeUpdate(prevProps:TProps, prevState:TState):Dynamic;
 	#end
-	
+
 	#if (js && !debug && !react_no_inline)
 	static function __init__():Void {
 		// required magic value to tag literal react elements

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -60,11 +60,6 @@ extern class ReactComponentOf<TProps, TState>
 	function render():ReactElement;
 
 	/**
-		https://facebook.github.io/react/docs/react-component.html#componentwillmount
-	**/
-	function componentWillMount():Void;
-
-	/**
 		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillmount
 	**/
 	function UNSAFE_componentWillMount():Void;
@@ -80,11 +75,6 @@ extern class ReactComponentOf<TProps, TState>
 	function componentWillUnmount():Void;
 
 	/**
-		https://facebook.github.io/react/docs/react-component.html#componentwillreceiveprops
-	**/
-	function componentWillReceiveProps(nextProps:TProps):Void;
-
-	/**
 		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillreceiveprops
 	**/
 	function UNSAFE_componentWillReceiveProps(nextProps:TProps):Void;
@@ -93,11 +83,6 @@ extern class ReactComponentOf<TProps, TState>
 		https://facebook.github.io/react/docs/react-component.html#shouldcomponentupdate
 	**/
 	dynamic function shouldComponentUpdate(nextProps:TProps, nextState:TState):Bool;
-
-	/**
-		https://facebook.github.io/react/docs/react-component.html#componentwillupdate
-	**/
-	function componentWillUpdate(nextProps:TProps, nextState:TState):Void;
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#unsafe_componentwillupdate


### PR DESCRIPTION
To keep it consistent with recent React API changes the following methods have been renamed:

- componentWillMount() -> UNSAFE_componentWillMount()
- componentWillReceiveProps() -> UNSAFE_componentWillReceiveProps()
- componentWillUpdate() -> UNSAFE_componentWillUpdate()