### PR TITLE
Making `componentDidUpdate` arguments optional for convenience

### DIFF
--- a/samples/todoapp/bin/index.html
+++ b/samples/todoapp/bin/index.html
@@ -12,8 +12,8 @@
 <body>
 	<link rel="stylesheet" href="styles.css"/>
 	<div id="app"></div>
-	<script src="//cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.development.js"></script>
-	<script src="//cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.development.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/react/16.3.0/umd/react.development.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.0/umd/react-dom.development.js"></script>
 	<script src="index.js"></script>
 </body>
 </html>

--- a/samples/todoapp/build.hxml
+++ b/samples/todoapp/build.hxml
@@ -4,7 +4,7 @@
 -lib react
 -lib msignal
 -D react_global
--D react_ver=16.2
+-D react_ver=16.3
 #-D react_no_inline
 -debug
 -dce full

--- a/samples/todoapp/src/view/TodoApp.hx
+++ b/samples/todoapp/src/view/TodoApp.hx
@@ -28,8 +28,8 @@ class TodoApp extends ReactComponentOfState<TodoAppState>
 		});
 	}
 
-	override function componentWillMount() {
-		trace('App will mount...');
+	override function componentDidUpdate() { // notice: args optional here
+		trace('App updated...');
 	}
 
 	override public function render()

--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -64,13 +64,13 @@ class ReactTypeMacro
 		// auto-declare arguments of `componentDidUpdate` for convenience
 		var updateArgs = Context.defined("react_snapshot_api") ? 3 : 2;
 		for (field in fields) {
-			if (field.name == "componentDidUpdate") {
+			if (field.name == 'componentDidUpdate') {
 				switch (field.kind) {
 					case FFun(f):
 						while (f.args.length < updateArgs) {
 							var index = f.args.length;
 							f.args.push({
-								name: 'arg$index',
+								name: '_',
 								opt: index == 2,
 								type: macro :Dynamic
 							});

--- a/src/lib/react/ReactTypeMacro.hx
+++ b/src/lib/react/ReactTypeMacro.hx
@@ -61,6 +61,26 @@ class ReactTypeMacro
 			default:
 		}
 
+		// auto-declare arguments of `componentDidUpdate` for convenience
+		var updateArgs = Context.defined("react_snapshot_api") ? 3 : 2;
+		for (field in fields) {
+			if (field.name == "componentDidUpdate") {
+				switch (field.kind) {
+					case FFun(f):
+						while (f.args.length < updateArgs) {
+							var index = f.args.length;
+							f.args.push({
+								name: 'arg$index',
+								opt: index == 2,
+								type: macro :Dynamic
+							});
+						}
+					default:
+				}
+				break;
+			}
+		}
+
 		// Only alter setState signature for non-dynamic states
 		if (!Context.defined('display'))
 			switch (ComplexTypeTools.toType(stateType))


### PR DESCRIPTION
So updating React lib won't break people's code without the new `snapshot` argument.
Generally it's very common in JS/TS to omit the `prevState`/`prevProps` arguments of this method.