### PR TITLE
Fix `__js__ is deprecated` warning

### DIFF
--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -127,7 +127,11 @@ extern class ReactComponentOf<TProps, TState>
 	#if (js && !debug && !react_no_inline)
 	static function __init__():Void {
 		// required magic value to tag literal react elements
+		#if !haxe4
 		untyped __js__("var $$tre = (typeof Symbol === \"function\" && Symbol.for && Symbol.for(\"react.element\")) || 0xeac7");
+		#else
+		js.Syntax.code("var $$tre = (typeof Symbol === \"function\" && Symbol.for && Symbol.for(\"react.element\")) || 0xeac7");
+		#end
 	}
 	#end
 }

--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -172,7 +172,7 @@ class ReactMacro
 			#if !haxe4
 			{field: "@$__hx__$$typeof", expr: macro untyped __js__("$$tre")},
 			#else
-			{field: "$$typeof", expr: macro untyped __js__("$$tre")},
+			{field: "$$typeof", expr: macro js.Syntax.code("$$tre")},
 			#end
 			{field: 'type', expr: type},
 			{field: 'props', expr: props}


### PR DESCRIPTION
When I use this library with Haxe 4.x, I get the following warning.

```sh
$ haxe --version
4.1.4
$ haxe build.hxml
/usr/local/lib/haxe/lib/react/1,11,1/src/lib/react/ReactMacro.hx:175: characters 44-50 : Warning : __js__ is deprecated, use js.Syntax.code instead
/usr/local/lib/haxe/lib/react/1,11,1/src/lib/react/ReactComponent.hx:130: characters 11-17 : Warning : __js__ is deprecated, use js.Syntax.code instead
```

This PR fixes the above warning in Haxe 4.x.
