### PR TITLE
Fix typo in HOC docs

### DIFF
--- a/doc/hoc-wrap.md
+++ b/doc/hoc-wrap.md
@@ -39,7 +39,7 @@ class MyComponent extends ReactComponentOfProps<RouteRenderProps> {
 }
 ```
 
-You can add multime `@:wrap` metas:
+You can add multiple `@:wrap` metas:
 
 ```haxe
 import react.ReactComponent;


### PR DESCRIPTION
Minor typo in the HOC docs for multiple wrapper support.