### PR TITLE
Implemented StrictMode into Haxe-React, and possibly more

### DIFF
--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -35,6 +35,18 @@ extern class React
 	**/
 	public static function isValidElement(object:Dynamic):Bool;
 
+	/**
+		https://react.dev/reference/react/useState
+		Note: this API has been introduced in React 16.8
+	**/
+	public static function useState<T>(initialValue:T):Array<T>;
+
+	/**
+		https://react.dev/reference/react/useEffect'
+		Note: this API has been introduced in React 16.8
+	**/
+	public static function useEffect(effect:Void->Void, ?inputs:Array<Dynamic>):Void;
+
 	#if react_context_api
 	/**
 		https://reactjs.org/docs/context.html#reactcreatecontext

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -35,18 +35,6 @@ extern class React
 	**/
 	public static function isValidElement(object:Dynamic):Bool;
 
-	/**
-		https://react.dev/reference/react/useState
-		Note: this API has been introduced in React 16.8
-	**/
-	public static function useState<T>(initialValue:T):Array<T>;
-
-	/**
-		https://react.dev/reference/react/useEffect'
-		Note: this API has been introduced in React 16.8
-	**/
-	public static function useEffect(effect:Void->Void, ?inputs:Array<Dynamic>):Void;
-
 	#if react_context_api
 	/**
 		https://reactjs.org/docs/context.html#reactcreatecontext

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -5,10 +5,17 @@ import react.ReactComponent.ReactElement;
 /**
 	https://facebook.github.io/react/docs/react-api.html
 **/
+
+#if (jsImport)
+@:js.import(@default "react")
+#else
+
 #if (!react_global)
 @:jsRequire("react")
 #end
+
 @:native('React')
+#end
 extern class React
 {
 	// Warning: react.React.PropTypes is deprecated, reference as react.ReactPropTypes

--- a/src/lib/react/React.hx
+++ b/src/lib/react/React.hx
@@ -60,6 +60,13 @@ extern class React
 	#end
 
 	/**
+		https://react.dev/reference/react/StrictMode
+
+		Note: this API has been introduced in React 16.3
+	**/
+	public static var StrictMode:CreateElementType;
+
+	/**
 		https://facebook.github.io/react/docs/react-api.html#react.children
 	**/
 	public static var Children:ReactChildren;

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -24,10 +24,16 @@ typedef ReactComponentOfState<TState> = ReactComponentOf<Empty, TState>;
 // Keep the old ReactComponentOfPropsAndState typedef available a few versions
 typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState>;
 
+#if (jsImport)
+@:js.import("react", "Component")
+#else
+
 #if (!react_global)
 @:jsRequire("react", "Component")
 #end
 @:native('React.Component')
+#end
+
 @:keepSub
 @:autoBuild(react.ReactComponentMacro.build())
 extern class ReactComponentOf<TProps, TState>

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -25,7 +25,7 @@ typedef ReactComponentOfState<TState> = ReactComponentOf<Empty, TState>;
 typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState>;
 
 #if (jsImport)
-@:js.import(@default "react")
+@:js.import(@default "react.Component")
 #else
 
 #if (!react_global)

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -24,17 +24,10 @@ typedef ReactComponentOfState<TState> = ReactComponentOf<Empty, TState>;
 // Keep the old ReactComponentOfPropsAndState typedef available a few versions
 typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState>;
 
-#if (jsImport)
-@:js.import(@default "react.Component")
-#else
-
 #if (!react_global)
 @:jsRequire("react", "Component")
 #end
 @:native('React.Component')
-
-#end
-
 @:keepSub
 @:autoBuild(react.ReactComponentMacro.build())
 extern class ReactComponentOf<TProps, TState>

--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -24,10 +24,17 @@ typedef ReactComponentOfState<TState> = ReactComponentOf<Empty, TState>;
 // Keep the old ReactComponentOfPropsAndState typedef available a few versions
 typedef ReactComponentOfPropsAndState<TProps, TState> = ReactComponentOf<TProps, TState>;
 
+#if (jsImport)
+@:js.import(@default "react")
+#else
+
 #if (!react_global)
 @:jsRequire("react", "Component")
 #end
 @:native('React.Component')
+
+#end
+
 @:keepSub
 @:autoBuild(react.ReactComponentMacro.build())
 extern class ReactComponentOf<TProps, TState>

--- a/src/lib/react/ReactDOM.hx
+++ b/src/lib/react/ReactDOM.hx
@@ -6,10 +6,16 @@ import js.html.Element;
 /**
 	https://facebook.github.io/react/docs/react-dom.html
 **/
+
+#if (jsImport)
+@:js.import(@default "react")
+#else
+
 #if (!react_global)
 @:jsRequire("react-dom")
 #end
 @:native('ReactDOM')
+#end
 extern class ReactDOM
 {
 	/**

--- a/src/lib/react/ReactDOM.hx
+++ b/src/lib/react/ReactDOM.hx
@@ -8,7 +8,7 @@ import js.html.Element;
 **/
 
 #if (jsImport)
-@:js.import(@default "react")
+@:js.import(@default "react-dom")
 #else
 
 #if (!react_global)

--- a/src/lib/react/ReactDOMClient.hx
+++ b/src/lib/react/ReactDOMClient.hx
@@ -1,0 +1,22 @@
+package react;
+
+import js.html.Element;
+
+/**
+    Note: this API has been introduced in React 18
+**/
+
+#if jsImport
+@:js.import(@default "react-dom/client")
+#else
+
+#if (!react_global)
+@:jsRequire("react-dom/client")
+#end
+
+@:native('ReactDOMClient')
+#end
+extern class ReactDOMClient {
+    public static function createRoot(container:Element, ?options:Null<Dynamic>):Dynamic;
+    public static function hydrateRoot(container:Element, children:ReactElement, ?options:Null<Dynamic>):Dynamic;
+}

--- a/src/lib/react/ReactDOMClient.hx
+++ b/src/lib/react/ReactDOMClient.hx
@@ -1,6 +1,7 @@
 package react;
 
 import js.html.Element;
+import react.ReactComponent.ReactElement;
 
 /**
     Note: this API has been introduced in React 18

--- a/src/lib/react/ReactDOMServer.hx
+++ b/src/lib/react/ReactDOMServer.hx
@@ -13,10 +13,16 @@ class ReactMarkupReadableStream extends Readable<ReactMarkupReadableStream> {}
 /**
 	https://facebook.github.io/react/docs/react-dom-server.html
 **/
+
+#if (jsImport)
+@:js.import(@default "react")
+#else
+
 #if (!react_global)
 @:jsRequire('react-dom/server')
 #end
 @:native('ReactDOMServer')
+#end
 extern class ReactDOMServer
 {
 	/**

--- a/src/lib/react/ReactDOMServer.hx
+++ b/src/lib/react/ReactDOMServer.hx
@@ -15,7 +15,7 @@ class ReactMarkupReadableStream extends Readable<ReactMarkupReadableStream> {}
 **/
 
 #if (jsImport)
-@:js.import(@default "react")
+@:js.import(@default "react-dom/server")
 #else
 
 #if (!react_global)


### PR DESCRIPTION
Added **StrictMode** as a static variable to our React extern class in Haxe. It's now possible to use `React.StrictMode` in the same way as any other React component in our Haxe-React codebase.

Here's an example:
```haxe
import js.Browser.document;

import react.ReactDOM;
import react.ReactComponent;
import react.ReactMacro.jsx;
import react.React;

@:jsRequire("./App.jsx", "default")
extern class App {}

function main() {
    js.Lib.require("./index.css");

    ReactDOM.render(
        jsx("<React.StrictMode><App /></React.StrictMode>"),
        document.getElementById("root")
    );
}
```